### PR TITLE
✨ ig delete

### DIFF
--- a/src/app/api/pig/[id]/delete/executive/route.js
+++ b/src/app/api/pig/[id]/delete/executive/route.js
@@ -1,0 +1,5 @@
+import { handleApiRequest } from "@/app/api/apiWrapper";
+
+export async function POST(request, { params }) {
+  return handleApiRequest("POST", "/api/executive/pig/{id}/delete", { params });
+}

--- a/src/app/api/pig/[id]/delete/route.js
+++ b/src/app/api/pig/[id]/delete/route.js
@@ -1,0 +1,5 @@
+import { handleApiRequest } from "@/app/api/apiWrapper";
+
+export async function POST(request, { params }) {
+  return handleApiRequest("POST", "/api/pig/{id}/delete", { params });
+}

--- a/src/app/api/sig/[id]/delete/executive/route.js
+++ b/src/app/api/sig/[id]/delete/executive/route.js
@@ -1,0 +1,5 @@
+import { handleApiRequest } from "@/app/api/apiWrapper";
+
+export async function POST(request, { params }) {
+  return handleApiRequest("POST", "/api/executive/sig/{id}/delete", { params });
+}

--- a/src/app/api/sig/[id]/delete/route.js
+++ b/src/app/api/sig/[id]/delete/route.js
@@ -1,0 +1,5 @@
+import { handleApiRequest } from "@/app/api/apiWrapper";
+
+export async function POST(request, { params }) {
+  return handleApiRequest("POST", "/api/sig/{id}/delete", { params });
+}

--- a/src/app/article/[id]/page.jsx
+++ b/src/app/article/[id]/page.jsx
@@ -10,6 +10,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import Comments from "@/components/board/Comments.jsx";
 import LoadingSpinner from "@/components/LoadingSpinner";
+import { TIME_NOTATION_OPTIONS } from "@/util/constants";
 
 export default function ArticleDetail({ params }) {
   const router = useRouter();
@@ -54,6 +55,10 @@ export default function ArticleDetail({ params }) {
     loadAll();
   }, [router, id]);
 
+  useEffect(() => {
+    console.log(article)
+  }, [article])
+
   if (isLoading) return <LoadingSpinner />;
 
   if (isError || !article) {
@@ -64,13 +69,14 @@ export default function ArticleDetail({ params }) {
     );
   }
 
+
   const markdown = article.content ?? "내용이 비어 있습니다.";
 
   return (
     <div className="SigDetailContainer">
       <h1 className="SigTitle">{article.title}</h1>
       <p className="SigInfo">
-        작성일: {new Date(article.created_at).toLocaleString()}
+        작성일: {TIME_NOTATION_OPTIONS(new Date(article.created_at.slice(0,23)))}
       </p>
       <hr className="SigDivider" />
       <div className="SigContent">

--- a/src/app/article/[id]/page.jsx
+++ b/src/app/article/[id]/page.jsx
@@ -10,7 +10,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import Comments from "@/components/board/Comments.jsx";
 import LoadingSpinner from "@/components/LoadingSpinner";
-import { TIME_NOTATION_OPTIONS } from "@/util/constants";
+import { UTC2KST } from "@/util/constants";
 
 export default function ArticleDetail({ params }) {
   const router = useRouter();
@@ -80,7 +80,7 @@ export default function ArticleDetail({ params }) {
     <div className="SigDetailContainer">
       <h1 className="SigTitle">{article.title}</h1>
       <p className="SigInfo">
-        작성일: {TIME_NOTATION_OPTIONS(new Date(article.created_at.slice(0,23)))}
+        작성일: {UTC2KST(new Date(article.created_at))}
       </p>
 
       {isAuthor && (

--- a/src/app/pig/[id]/PigClient.jsx
+++ b/src/app/pig/[id]/PigClient.jsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import PigJoinLeaveButton from "./PigJoinLeaveButton";
 import EditPigButton from "./EditPigButton";
+import PigDeleteButton from "./PigDeleteButton";
 import PigMembers from "./PigMembers";
 import PigContents from "./PigContents";
 import LoadingSpinner from "@/components/LoadingSpinner";
@@ -25,6 +26,12 @@ export default function PigClient({ pig, members, articleId, pigId }) {
     const roleOk = typeof me?.role === "number" && me.role >= minExecutiveLevel;
     const ownerOk = !!pig?.owner && pig.owner === me.id;
     return roleOk || ownerOk;
+  }, [me, pig]);
+
+  const isOwner = useMemo(() => {
+    if (!me) return false;
+    const ownerOk = !!pig?.owner && pig.owner === me.id;
+    return ownerOk;
   }, [me, pig]);
 
   useEffect(() => {
@@ -82,6 +89,7 @@ export default function PigClient({ pig, members, articleId, pigId }) {
       <div className="PigActionRow">
         <PigJoinLeaveButton pigId={pigId} initialIsMember={isMember} />
         <EditPigButton pigId={pigId} canEdit={canEdit} />
+        <PigDeleteButton pigId={pigId} canDelete={canEdit} isOwner={isOwner} />
       </div>
       <hr className="PigDivider" />
       <PigContents content={content} />

--- a/src/app/pig/[id]/PigClient.jsx
+++ b/src/app/pig/[id]/PigClient.jsx
@@ -8,6 +8,7 @@ import PigDeleteButton from "./PigDeleteButton";
 import PigMembers from "./PigMembers";
 import PigContents from "./PigContents";
 import LoadingSpinner from "@/components/LoadingSpinner";
+import { minExecutiveLevel } from "@/util/constants";
 
 export default function PigClient({ pig, members, articleId, pigId }) {
   const router = useRouter();
@@ -22,7 +23,9 @@ export default function PigClient({ pig, members, articleId, pigId }) {
 
   const canEdit = useMemo(() => {
     if (!me) return false;
-    return !!pig?.owner && pig.owner === me.id;
+    const roleOk = typeof me?.role === "number" && me.role >= minExecutiveLevel;
+    const ownerOk = !!pig?.owner && pig.owner === me.id;
+    return roleOk || ownerOk;
   }, [me, pig]);
 
   const isOwner = useMemo(() => {

--- a/src/app/pig/[id]/PigDeleteButton.jsx
+++ b/src/app/pig/[id]/PigDeleteButton.jsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+
+export default function PigDeleteButton({ pigId, canDelete, isOwner }) {
+  const [pending, setPending] = useState(false);
+  const router = useRouter();
+
+  const ensureJwt = () => {
+    const jwt = localStorage.getItem("jwt");
+    if (!jwt) {
+      alert("로그인이 필요합니다.");
+      router.replace("/us/login");
+    }
+    return jwt;
+  };
+
+  const readError = async (res) => {
+    const base = `HTTP ${res.status}`;
+    const ct = res.headers.get("content-type") || "";
+    try {
+      if (ct.includes("application/json")) {
+        const body = await res.json();
+        const detail = body?.detail ?? body?.message ?? body?.error;
+        return detail
+          ? `${base} - ${detail}`
+          : `${base} - ${JSON.stringify(body)}`;
+      } else {
+        const text = await res.text();
+        return text ? `${base} - ${text}` : base;
+      }
+    } catch {
+      return base;
+    }
+  };
+
+  const deleteBySelf = async () => {
+    const jwt = ensureJwt();
+    if (!jwt) return;
+    try {
+      setPending(true);
+      const res = await fetch(`/api/pig/${pigId}/delete`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-jwt": jwt },
+      });
+      if (res.ok) {
+        alert("PIG 비활성화 성공!");
+        router.refresh();
+      } else {
+        alert("PIG 비활성화 실패: " + (await readError(res)));
+      }
+    } catch (e) {
+      alert("PIG 비활성화 실패: " + (e?.message || "네트워크 오류"));
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const deleteByExec = async () => {
+    const jwt = ensureJwt();
+    if (!jwt) return;
+    try {
+      setPending(true);
+      const res = await fetch(`/api/pig/${pigId}/delete/executive`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-jwt": jwt },
+      });
+      if (res.ok) {
+        alert("PIG 비활성화 성공!");
+        router.refresh();
+      } else {
+        alert("PIG 비활성화 실패: " + (await readError(res)));
+      }
+    } catch (e) {
+      alert("PIG 비활성화 실패: " + (e?.message || "네트워크 오류"));
+    } finally {
+      setPending(false);
+    }
+  };
+
+
+  return canDelete ? (
+    <button
+      type="button"
+      className={`PigButton is-delete`}
+      onClick={isOwner ? deleteBySelf : deleteByExec}
+      disabled={pending}
+      aria-busy={pending}
+    >
+      {"피그 비활성화"}
+    </button>
+  ) : null;
+}

--- a/src/app/pig/[id]/PigJoinLeaveButton.jsx
+++ b/src/app/pig/[id]/PigJoinLeaveButton.jsx
@@ -46,13 +46,14 @@ export default function PigJoinLeaveButton({ pigId, initialIsMember = false }) {
         headers: { "Content-Type": "application/json", "x-jwt": jwt },
       });
       if (res.ok) {
+        alert("PIG 가입 성공!");
         setIsMember(true);
         router.refresh();
       } else {
-        alert("SIG 가입 실패: " + (await readError(res)));
+        alert("PIG 가입 실패: " + (await readError(res)));
       }
     } catch (e) {
-      alert("SIG 가입 실패: " + (e?.message || "네트워크 오류"));
+      alert("PIG 가입 실패: " + (e?.message || "네트워크 오류"));
     } finally {
       setPending(false);
     }
@@ -68,13 +69,14 @@ export default function PigJoinLeaveButton({ pigId, initialIsMember = false }) {
         headers: { "Content-Type": "application/json", "x-jwt": jwt },
       });
       if (res.ok) {
+        alert("PIG 탈퇴 성공!");
         setIsMember(false);
         router.refresh();
       } else {
-        alert("SIG 탈퇴 실패: " + (await readError(res)));
+        alert("PIG 탈퇴 실패: " + (await readError(res)));
       }
     } catch (e) {
-      alert("SIG 탈퇴 실패: " + (e?.message || "네트워크 오류"));
+      alert("PIG 탈퇴 실패: " + (e?.message || "네트워크 오류"));
     } finally {
       setPending(false);
     }
@@ -88,7 +90,7 @@ export default function PigJoinLeaveButton({ pigId, initialIsMember = false }) {
       disabled={pending}
       aria-busy={pending}
     >
-      {isMember ? "시그 탈퇴하기" : "시그 가입하기"}
+      {isMember ? "피그 탈퇴하기" : "피그 가입하기"}
     </button>
   );
 }

--- a/src/app/pig/[id]/PigMembers.jsx
+++ b/src/app/pig/[id]/PigMembers.jsx
@@ -9,7 +9,7 @@ export default function PigMembers({ members }) {
     >
       <div className="PigMembersHeader">
         <h2 id="pig-members-heading" className="PigMembersTitle">
-          시그 인원
+          피그 인원
         </h2>
         <span className="PigMembersCount">{count}명</span>
       </div>

--- a/src/app/pig/[id]/page.css
+++ b/src/app/pig/[id]/page.css
@@ -317,7 +317,8 @@ body {
   border-style: dashed;
 }
 
-.PigButton.is-edit {
+.PigButton.is-delete:not(:hover) {
+  background-color: red;
 }
 
 @media (max-width: 560px) {

--- a/src/app/pig/[id]/page.css
+++ b/src/app/pig/[id]/page.css
@@ -318,7 +318,12 @@ body {
 }
 
 .PigButton.is-delete:not(:hover) {
-  background-color: red;
+  background-color: var(--color-button-alert-bg);
+  border-style: solid;
+}
+
+.PigButton.is-delete:hover {
+  background-color: var(--color-button-alert-hover-bg);
   border-style: solid;
 }
 

--- a/src/app/sig/[id]/SigClient.jsx
+++ b/src/app/sig/[id]/SigClient.jsx
@@ -8,6 +8,7 @@ import SigDeleteButton from "./SigDeleteButton";
 import SigMembers from "./SigMembers";
 import SigContents from "./SigContents";
 import LoadingSpinner from "@/components/LoadingSpinner";
+import { minExecutiveLevel } from "@/util/constants";
 
 export default function SigClient({ sig, members, articleId, sigId }) {
   const router = useRouter();
@@ -22,7 +23,9 @@ export default function SigClient({ sig, members, articleId, sigId }) {
 
   const canEdit = useMemo(() => {
     if (!me) return false;
-    return !!sig?.owner && sig.owner === me.id;
+    const roleOk = typeof me?.role === "number" && me.role >= minExecutiveLevel;
+    const ownerOk = !!sig?.owner && sig.owner === me.id;
+    return roleOk || ownerOk;
   }, [me, sig]);
 
   const isOwner = useMemo(() => {

--- a/src/app/sig/[id]/SigClient.jsx
+++ b/src/app/sig/[id]/SigClient.jsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import SigJoinLeaveButton from "./SigJoinLeaveButton";
 import EditSigButton from "./EditSigButton";
+import SigDeleteButton from "./SigDeleteButton";
 import SigMembers from "./SigMembers";
 import SigContents from "./SigContents";
 import LoadingSpinner from "@/components/LoadingSpinner";
@@ -25,6 +26,12 @@ export default function SigClient({ sig, members, articleId, sigId }) {
     const roleOk = typeof me?.role === "number" && me.role >= minExecutiveLevel;
     const ownerOk = !!sig?.owner && sig.owner === me.id;
     return roleOk || ownerOk;
+  }, [me, sig]);
+
+  const isOwner = useMemo(() => {
+    if (!me) return false;
+    const ownerOk = !!sig?.owner && sig.owner === me.id;
+    return ownerOk;
   }, [me, sig]);
 
   useEffect(() => {
@@ -82,6 +89,7 @@ export default function SigClient({ sig, members, articleId, sigId }) {
       <div className="SigActionRow">
         <SigJoinLeaveButton sigId={sigId} initialIsMember={isMember} />
         <EditSigButton sigId={sigId} canEdit={canEdit} />
+        <SigDeleteButton sigId={sigId} canDelete={canEdit} isOwner={isOwner}/>
       </div>
       <hr className="SigDivider" />
       <SigContents content={content} />

--- a/src/app/sig/[id]/SigDeleteButton.jsx
+++ b/src/app/sig/[id]/SigDeleteButton.jsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+
+export default function SigDeleteButton({ sigId, canDelete, isOwner }) {
+  const [pending, setPending] = useState(false);
+  const router = useRouter();
+
+  const ensureJwt = () => {
+    const jwt = localStorage.getItem("jwt");
+    if (!jwt) {
+      alert("로그인이 필요합니다.");
+      router.replace("/us/login");
+    }
+    return jwt;
+  };
+
+  const readError = async (res) => {
+    const base = `HTTP ${res.status}`;
+    const ct = res.headers.get("content-type") || "";
+    try {
+      if (ct.includes("application/json")) {
+        const body = await res.json();
+        const detail = body?.detail ?? body?.message ?? body?.error;
+        return detail
+          ? `${base} - ${detail}`
+          : `${base} - ${JSON.stringify(body)}`;
+      } else {
+        const text = await res.text();
+        return text ? `${base} - ${text}` : base;
+      }
+    } catch {
+      return base;
+    }
+  };
+
+  const deleteBySelf = async () => {
+    const jwt = ensureJwt();
+    if (!jwt) return;
+    try {
+      setPending(true);
+      const res = await fetch(`/api/sig/${sigId}/delete`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-jwt": jwt },
+      });
+      if (res.ok) {
+        alert("SIG 비활성화 성공!");
+        router.refresh();
+      } else {
+        alert("SIG 비활성화 실패: " + (await readError(res)));
+      }
+    } catch (e) {
+      alert("SIG 비활성화 실패: " + (e?.message || "네트워크 오류"));
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const deleteByExec = async () => {
+    const jwt = ensureJwt();
+    if (!jwt) return;
+    try {
+      setPending(true);
+      const res = await fetch(`/api/sig/${sigId}/delete/executive`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-jwt": jwt },
+      });
+      if (res.ok) {
+        alert("SIG 비활성화 성공!");
+        router.refresh();
+      } else {
+        alert("SIG 비활성화 실패: " + (await readError(res)));
+      }
+    } catch (e) {
+      alert("SIG 비활성화 실패: " + (e?.message || "네트워크 오류"));
+    } finally {
+      setPending(false);
+    }
+  };
+
+
+  return canDelete ? (
+    <button
+      type="button"
+      className={`SigButton is-delete`}
+      onClick={isOwner ? deleteBySelf : deleteByExec}
+      disabled={pending}
+      aria-busy={pending}
+    >
+      {"시그 비활성화"}
+    </button>
+  ) : null;
+}

--- a/src/app/sig/[id]/page.css
+++ b/src/app/sig/[id]/page.css
@@ -318,7 +318,13 @@ body {
 }
 
 .SigButton.is-delete:not(:hover) {
-  background-color: red;
+  background-color: var(--color-button-alert-bg);
+  border-style: solid;
+}
+
+.SigButton.is-delete:hover {
+  background-color: var(--color-button-alert-hover-bg);
+  border-style: solid;
 }
 
 @media (max-width: 560px) {

--- a/src/app/sig/[id]/page.css
+++ b/src/app/sig/[id]/page.css
@@ -317,7 +317,8 @@ body {
   border-style: dashed;
 }
 
-.SigButton.is-edit {
+.SigButton.is-delete:not(:hover) {
+  background-color: red;
 }
 
 @media (max-width: 560px) {

--- a/src/components/board/ArticlesView.jsx
+++ b/src/components/board/ArticlesView.jsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import LoadingSpinner from "@/components/LoadingSpinner";
-import { TIME_NOTATION_OPTIONS } from "@/util/constants";
+import { UTC2KST } from "@/util/constants";
 import "./board.css";
 
 export default function ArticlesView({ board, sortOrder }) {
@@ -86,7 +86,7 @@ export default function ArticlesView({ board, sortOrder }) {
             <div className="sigTopbar">
               <span className="sigTitle">{article.title}</span>
               <span className="sigUserCount">
-                {TIME_NOTATION_OPTIONS(new Date(article.created_at))}
+                {UTC2KST(new Date(article.created_at))}
               </span>
             </div>
             <div className="sigDescription">

--- a/src/components/board/ArticlesView.jsx
+++ b/src/components/board/ArticlesView.jsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import LoadingSpinner from "@/components/LoadingSpinner";
+import { TIME_NOTATION_OPTIONS } from "@/util/constants";
 import "./board.css";
 
 export default function ArticlesView({ board, sortOrder }) {
@@ -85,7 +86,7 @@ export default function ArticlesView({ board, sortOrder }) {
             <div className="sigTopbar">
               <span className="sigTitle">{article.title}</span>
               <span className="sigUserCount">
-                {new Date(article.created_at).toLocaleDateString()}
+                {TIME_NOTATION_OPTIONS(new Date(article.created_at))}
               </span>
             </div>
             <div className="sigDescription">

--- a/src/components/board/BoardClient.jsx
+++ b/src/components/board/BoardClient.jsx
@@ -11,13 +11,13 @@ export default function BoardClient({ board }) {
   return (
     <>
       {/* 상단 버튼 영역 */}
-      <div className="SigActions">
+      <div className="BoardActions">
         <div className="left-action">
           <SortDropdown sortOrder={sortOrder} setSortOrder={setSortOrder} />
         </div>
         <div className="right-action">
-          <a href={`/board/${board.id}/create`} id="SigCreateButton">
-            <button className="SigCreateBtn">글 작성</button>
+          <a href={`/board/${board.id}/create`} id="BoardCreateButton">
+            <button className="BoardCreateBtn">글 작성</button>
           </a>
         </div>
       </div>

--- a/src/components/board/board.css
+++ b/src/components/board/board.css
@@ -49,11 +49,11 @@
   white-space: normal;
 }
 
-#SigCreateButton {
+#BoardCreateButton {
   all: unset;
 }
 
-.SigCreateBtn {
+.BoardCreateBtn {
   background-color: var(--color-button-bg);
   color: var(--color-button-text);
   padding: 0.6rem 1.2rem;
@@ -63,7 +63,7 @@
   transition: background-color 0.2s ease;
 }
 
-.SigCreateBtn:hover {
+.BoardCreateBtn:hover {
   background-color: var(--color-button-hover-bg);
 }
 
@@ -122,7 +122,7 @@
   text-align: center;
 }
 
-.SigActions {
+.BoardActions {
   display: flex;
   justify-content: space-between; /* 좌우 끝 정렬 */
   align-items: center;
@@ -131,17 +131,17 @@
 
 /* 모바일 대응 */
 @media (max-width: 768px) {
-  .SigActions {
+  .BoardActions {
     flex-direction: row; /* 세로 말고 가로 유지 */
     justify-content: space-between; /* 좌우 끝 */
     width: 100%;
   }
-  .SigActions > * {
+  .BoardActions > * {
     width: auto; /* 버튼이 가득 차지하지 않게 */
   }
 }
 
-.SigActions {
+.BoardActions {
   display: flex;
   justify-content: space-between; /* 왼쪽과 오른쪽 끝 */
   align-items: center;
@@ -161,7 +161,7 @@
 
 /* 모바일 대응 */
 @media (max-width: 768px) {
-  .SigActions {
+  .BoardActions {
     flex-direction: row;
     justify-content: space-between;
     gap: 0.5rem;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -13,9 +13,11 @@ html.theme-animating {
 :root {
   --color-primary: #bbbcbc;
   --color-button-bg: #128e9f;
+  --color-button-alert-bg: red;
   --color-button-border: #527a91;
   --color-button-text: white;
   --color-button-hover-bg: #24737d;
+  --color-button-alert-hover-bg: rgb(177, 0, 0);
   --color-text-body: #2a2a2a;
   --color-text-subtle: #1b1b1b;
   --color-surface-light: #cccccc;

--- a/src/util/constants.jsx
+++ b/src/util/constants.jsx
@@ -19,3 +19,17 @@ export const DEPOSIT_ACC = '국민 923801-00-058488';
 export const DISCORD_INVITE_LINK = 'https://discord.gg/d9McArjXq5'
 
 export const KAKAO_INVITE_LINK = 'https://invite.kakao.com/tc/Nfp743zYME'
+
+export function TIME_NOTATION_OPTIONS(date) {
+  const utc = date.getTime();
+  const kst = new Date(utc + 9 * 60 * 60 * 1000);
+
+  return kst.toLocaleString("ko-KR", {
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+    second: "numeric",
+  });
+}

--- a/src/util/constants.jsx
+++ b/src/util/constants.jsx
@@ -20,7 +20,7 @@ export const DISCORD_INVITE_LINK = 'https://discord.gg/d9McArjXq5'
 
 export const KAKAO_INVITE_LINK = 'https://invite.kakao.com/tc/Nfp743zYME'
 
-export function TIME_NOTATION_OPTIONS(date) {
+export function UTC2KST(date) {
   const utc = date.getTime();
   const kst = new Date(utc + 9 * 60 * 60 * 1000);
 


### PR DESCRIPTION
- fixes #112 
- fixes #127 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added “Deactivate” buttons on SIG and Pig detail pages: owners can self-deactivate; authorized non-owners use an executive path. Includes login checks, clear success/error alerts, disabled state while processing, and auto-refresh on success.
- Improvements
  - Standardized date/time display to full Korean locale across articles and lists.
  - Updated join/leave messaging and labels to use "피그" and added success alerts.
  - SIG detail now shows a loading state while user/article data loads.
- Style
  - Added red alert styling for delete buttons and dashed border for leave buttons.
- Refactor
  - Renamed board action/create identifiers for consistency (no behavior change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->