### PR TITLE
✨ feat/bot-login

### DIFF
--- a/src/app/api/apiWrapper.js
+++ b/src/app/api/apiWrapper.js
@@ -41,7 +41,7 @@ export async function handleApiRequest(
   const res = await fetch(fullUrl, {
     method: method,
     headers: {
-      "Content-Type": requestBody && "application/json",
+      "Content-Type": requestBody ? "application/json" : undefined,
       "x-api-secret": getApiSecret(),
       "x-jwt": jwt,
     },

--- a/src/app/api/bot/discord/login/route.js
+++ b/src/app/api/bot/discord/login/route.js
@@ -1,5 +1,5 @@
 import { handleApiRequest } from "@/app/api/apiWrapper";
 
-export async function POST(request, {  }) {
-  return handleApiRequest("POST", "/api/executive/bot/discord/login", {  });
+export async function POST() {
+  return handleApiRequest("POST", "/api/bot/discord/login");
 }

--- a/src/app/executive/DiscordBotPanel.jsx
+++ b/src/app/executive/DiscordBotPanel.jsx
@@ -2,10 +2,8 @@
 "use client";
 export default function DiscordBotPanel({ is_logged_in }) {
   const discordLogin = async () => {
-    const jwt = localStorage.getItem("jwt");
     const res = await fetch(`/api/bot/discord/login`, {
       method: "POST",
-      headers: { "Content-Type": "application/json", "x-jwt": jwt },
     });
     if (res.status === 204) alert("로그인 성공!");
     else alert(`로그인 실패: ${await res.text()}`);

--- a/src/app/us/(auth)/login/page.jsx
+++ b/src/app/us/(auth)/login/page.jsx
@@ -1,5 +1,19 @@
+import { getBaseUrl } from "@/util/getBaseUrl";
 import AuthClient from "./AuthClient";
+import { getApiSecret } from "@/util/getApiSecret";
 
-export default function Page() {
+export default async function Page() {
+  const discordLogin = async () => {
+    const res = await fetch(`${getBaseUrl()}/api/bot/discord/login`, {
+      method: "POST",
+      headers: {
+        "x-api-secret": getApiSecret(),
+      },
+    });
+    if (res.status === 204) console.log("봇 로그인 성공");
+    else console.log(`봇 로그인 실패: ${await res.text()}`);
+  };
+  await discordLogin();
+
   return <AuthClient />;
 }


### PR DESCRIPTION
- scsc-init/homepage_init_backend#87 에 맞춰 API 경로 변경
- 로그인 페이지 접속 시 봇 로그인을 요청하게 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Simplified Discord bot login flow: client-side token no longer required and login is auto-initiated during the US login page load.
  - Bot login endpoint consolidated to /api/bot/discord/login.

- Chores
  - API consumers should switch to the new /api/bot/discord/login path.
  - Do not send JWT or related headers when calling the bot login endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->