### PR TITLE
feat/oldboy

### DIFF
--- a/src/app/api/executive/user/oldboy/[id]/process/route.js
+++ b/src/app/api/executive/user/oldboy/[id]/process/route.js
@@ -1,0 +1,7 @@
+import { handleApiRequest } from "@/app/api/apiWrapper";
+
+export async function POST(request, { params }) {
+  return handleApiRequest("POST", "/api/executive/user/oldboy/{id}/process", {
+    params,
+  });
+}

--- a/src/app/api/executive/user/oldboy/applicants/route.js
+++ b/src/app/api/executive/user/oldboy/applicants/route.js
@@ -1,0 +1,5 @@
+import { handleApiRequest } from "@/app/api/apiWrapper";
+
+export async function GET() {
+  return handleApiRequest("GET", "/api/executive/user/oldboy/applicants");
+}

--- a/src/app/api/user/oldboy/applicant/route.js
+++ b/src/app/api/user/oldboy/applicant/route.js
@@ -1,0 +1,5 @@
+import { handleApiRequest } from "@/app/api/apiWrapper";
+
+export async function GET() {
+  return handleApiRequest("GET", "/api/user/oldboy/applicant");
+}

--- a/src/app/api/user/oldboy/reactivate/route.js
+++ b/src/app/api/user/oldboy/reactivate/route.js
@@ -1,0 +1,5 @@
+import { handleApiRequest } from "@/app/api/apiWrapper";
+
+export async function POST() {
+  return handleApiRequest("POST", "/api/user/oldboy/reactivate");
+}

--- a/src/app/api/user/oldboy/register/route.js
+++ b/src/app/api/user/oldboy/register/route.js
@@ -1,0 +1,5 @@
+import { handleApiRequest } from "@/app/api/apiWrapper";
+
+export async function POST() {
+  return handleApiRequest("POST", "/api/user/oldboy/register");
+}

--- a/src/app/api/user/oldboy/unregister/route.js
+++ b/src/app/api/user/oldboy/unregister/route.js
@@ -1,0 +1,5 @@
+import { handleApiRequest } from "@/app/api/apiWrapper";
+
+export async function POST() {
+  return handleApiRequest("POST", "/api/user/oldboy/unregister");
+}

--- a/src/app/executive/user/OldboyManagementPanel.jsx
+++ b/src/app/executive/user/OldboyManagementPanel.jsx
@@ -1,0 +1,73 @@
+// src/app/executive/user/EnrollManagementPanel.jsx (CLIENT)
+"use client";
+import { useEffect, useState } from "react";
+
+export default function OldboyManageMentPanel({ users }) {
+  const [applicants, setApplicants] = useState([]);
+  const [saving, setSaving] = useState({});
+
+  useEffect(() => {
+    const jwt = localStorage.getItem("jwt");
+    if (!jwt) return;
+    const fetchApplicants = async () => {
+      const res = await fetch(`/api/executive/user/oldboy/applicants`, {
+        headers: { "x-jwt": jwt },
+      });
+      if (res.ok) setApplicants(await res.json());
+    };
+    fetchApplicants();
+  }, []);
+
+  const processOldboy = async (user) => {
+    const jwt = localStorage.getItem("jwt");
+    setSaving((prev) => ({ ...prev, [user.id]: true }));
+    const res = await fetch(`/api/executive/user/oldboy/${user.id}/process`, {
+      method: "POST",
+      headers: { "x-jwt": jwt },
+    });
+    if (res.status === 204) alert(`${user.name} 졸업생 전환 승인 완료`);
+    else alert(`${user.name} 승인 실패: ${res.status}`);
+    setSaving((prev) => ({ ...prev, [user.id]: false }));
+  };
+
+  return (
+    <div>
+      <h2>졸업생 전환 신청자 목록</h2>
+      <div className="adm-table-wrap">
+        <table className="adm-table">
+          <thead>
+            <tr>
+              <th className="adm-th">이름</th>
+              <th className="adm-th">신청시각</th>
+              <th className="adm-th">처리시각</th>
+              <th className="adm-th">처리여부</th>
+              <th className="adm-th">승인버튼</th>
+            </tr>
+          </thead>
+          <tbody>
+            {applicants.map((u) => {
+              const user = users.find((x) => x.id === u.id);
+              return (
+                <tr key={u.id}>
+                  <td className="adm-td">{user.name}</td>
+                  <td className="adm-td">{u.created_at}</td>
+                  <td className="adm-td">{u.updated_at}</td>
+                  <td className="adm-td">{u.processed ? "✅" : "❌"}</td>
+                  <td className="adm-td">
+                    <button
+                      className="adm-button"
+                      onClick={() => processOldboy(user)}
+                      disabled={saving[user.id]}
+                    >
+                      승인
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/executive/user/page.jsx
+++ b/src/app/executive/user/page.jsx
@@ -2,6 +2,7 @@
 import WithAuthorization from "@/components/WithAuthorization";
 import UserList from "./UserList";
 import EnrollManagementPanel from "./EnrollManagementPanel";
+import OldboyManageMentPanel from "./OldboyManagementPanel";
 import { getBaseUrl } from "@/util/getBaseUrl";
 import { getApiSecret } from "@/util/getApiSecret";
 import "../page.css";
@@ -21,6 +22,9 @@ export default async function ExecutiveUserPage() {
         </div>
         <div className="adm-section">
           <EnrollManagementPanel />
+        </div>
+        <div className="adm-section">
+          <OldboyManageMentPanel users={users} />
         </div>
       </div>
     </WithAuthorization>

--- a/src/util/constants.jsx
+++ b/src/util/constants.jsx
@@ -3,6 +3,8 @@
 export const minExecutiveLevel = 500;
 // 관리자의 최소 권한입니다. BE의 role level과 name을 관리할 때, 관리자는 반드시 이 변수 이상의 권한을, 비관리자는 이 변수 미만의 권한을 가지고 있어야 합니다.
 // 헤더에서 '운영진 페이지'를 표시할지 결정하는 데에 사용됩니다.
+export const oldboyLevel = 400;
+// 졸업생 권한의 값입니다. 내 정보 수정 페이지에서 사용됩니다.
 
 export const COLORS = {
   primary: "var(--color-primary)",
@@ -25,7 +27,6 @@ export const DEPOSIT_ACC = pickEnv(
   process.env.DEPOSIT_ACC,
   "국민은행 942902-02-054136 (강명석)",
 );
-
 
 export const DISCORD_INVITE_LINK = pickEnv(
   process.env.NEXT_PUBLIC_DISCORD_INVITE_LINK,


### PR DESCRIPTION
- 내 정보 수정 페이지 하단에 버튼을 추가함
  - if 사용자 권한==`졸업생`, then `정회원으로 전환` 버튼 표시
  - else if 졸업생 전환신청 기록 존재, then `졸업생 전환신청 취소` 버튼 표시
  - else `졸업생 전환신청` 버튼 표시
- 관리자 페이지의 유저 관리 페이지 하단에 `졸업생 전환 신청자 목록` 추가
  - 신청자의 이름, 신청시각, 처리시각(`updated_at`), 처리여부 확인 및 전환신청 `승인` 버튼 존재

scsc-init/homepage_init_backend#91 과 함께 작동되는 것을 상정함