### PR TITLE
⚡️ sig owner highlight, 🚑️ add google pfp image domain to config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,14 @@ const nextConfig = {
     });
     return config;
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'lh3.googleusercontent.com'
+      }
+    ]
+  }
 };
 
 export default nextConfig;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,14 +7,6 @@ const nextConfig = {
     });
     return config;
   },
-  images: {
-    remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'lh3.googleusercontent.com'
-      }
-    ]
-  }
 };
 
 export default nextConfig;

--- a/src/app/header.css
+++ b/src/app/header.css
@@ -57,7 +57,7 @@
 .HeaderRight__main {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 1.5rem;
 }
 
 .HeaderRight__executive {

--- a/src/app/pig/[id]/PigClient.jsx
+++ b/src/app/pig/[id]/PigClient.jsx
@@ -87,7 +87,7 @@ export default function PigClient({ pig, members, articleId, pigId }) {
       <hr className="PigDivider" />
       <PigContents content={content} />
       <hr />
-      <PigMembers members={members} />
+      <PigMembers owner={pig?.owner} members={members} />
     </div>
   );
 }

--- a/src/app/pig/[id]/PigMembers.jsx
+++ b/src/app/pig/[id]/PigMembers.jsx
@@ -1,5 +1,9 @@
-export default function PigMembers({ members }) {
-  const list = Array.isArray(members) ? members : [];
+export default function PigMembers({ owner, members }) {
+  const rawList = Array.isArray(members) ? members : [];
+  const ownerIndex = !!owner ? rawList.findIndex(m => m.id === owner) : -1
+  const list = ownerIndex === -1
+    ? rawList
+    : [rawList[ownerIndex], ...rawList.slice(0, ownerIndex), ...rawList.slice(ownerIndex + 1)];
   const count = list.length;
 
   return (
@@ -16,9 +20,15 @@ export default function PigMembers({ members }) {
       ) : (
         <ul className="PigMemberList">
           {list.map((m) => (
-            <li key={m.id} className="PigMemberChip">
-              {m.name}
-            </li>
+            m.id === owner ? (
+              <li key={m.id} className="PigMemberOwner">
+                {m.name}
+              </li>
+            ) : (
+              <li key={m.id} className="PigMemberChip">
+                {m.name}
+              </li>
+              )
           ))}
         </ul>
       )}

--- a/src/app/pig/[id]/page.css
+++ b/src/app/pig/[id]/page.css
@@ -437,6 +437,16 @@ body {
   box-shadow: 0 1px 3px var(--executive-card-shadow);
 }
 
+.PigMemberOwner {
+  padding: 0.45rem 0.75rem;
+  border-radius: 9999px;
+  background: var(--color-text-body);
+  border: 1px solid var(--color-button-border);
+  color: var(--executive-card-bg);
+  font-weight: bold;
+  box-shadow: 0 1px 3px var(--executive-card-shadow);
+}
+
 .PigMembersEmpty {
   padding: 0.9rem 0.75rem;
   border-radius: 0.5rem;

--- a/src/app/sig/[id]/SigClient.jsx
+++ b/src/app/sig/[id]/SigClient.jsx
@@ -87,7 +87,7 @@ export default function SigClient({ sig, members, articleId, sigId }) {
       <hr className="SigDivider" />
       <SigContents content={content} />
       <hr />
-      <SigMembers members={members} />
+      <SigMembers owner={sig?.owner} members={members} />
     </div>
   );
 }

--- a/src/app/sig/[id]/SigMembers.jsx
+++ b/src/app/sig/[id]/SigMembers.jsx
@@ -1,6 +1,16 @@
-export default function SigMembers({ members }) {
-  const list = Array.isArray(members) ? members : [];
+import { useEffect } from "react";
+
+export default function SigMembers({ owner, members }) {
+  const rawList = Array.isArray(members) ? members : [];
+  const ownerIndex = !!owner ? rawList.findIndex(m => m.id === owner) : -1
+  const list = ownerIndex === -1
+    ? rawList
+    : [rawList[ownerIndex], ...rawList.slice(0, ownerIndex), ...rawList.slice(ownerIndex + 1)];
   const count = list.length;
+
+  useEffect(() => {
+    console.log(owner, members)
+  }, [owner, members])
 
   return (
     <section className="SigMembersSection" aria-labelledby="sig-members-heading">
@@ -16,9 +26,15 @@ export default function SigMembers({ members }) {
       ) : (
         <ul className="SigMemberList">
           {list.map((m) => (
-            <li key={m.id} className="SigMemberChip">
-              {m.name}
-            </li>
+            m.id === owner ? (
+              <li key={m.id} className="SigMemberOwner">
+                {m.name}
+              </li>
+            ) : (
+              <li key={m.id} className="SigMemberChip">
+                {m.name}
+              </li>
+              )
           ))}
         </ul>
       )}

--- a/src/app/sig/[id]/SigMembers.jsx
+++ b/src/app/sig/[id]/SigMembers.jsx
@@ -1,5 +1,3 @@
-import { useEffect } from "react";
-
 export default function SigMembers({ owner, members }) {
   const rawList = Array.isArray(members) ? members : [];
   const ownerIndex = !!owner ? rawList.findIndex(m => m.id === owner) : -1
@@ -7,10 +5,6 @@ export default function SigMembers({ owner, members }) {
     ? rawList
     : [rawList[ownerIndex], ...rawList.slice(0, ownerIndex), ...rawList.slice(ownerIndex + 1)];
   const count = list.length;
-
-  useEffect(() => {
-    console.log(owner, members)
-  }, [owner, members])
 
   return (
     <section className="SigMembersSection" aria-labelledby="sig-members-heading">

--- a/src/app/sig/[id]/page.css
+++ b/src/app/sig/[id]/page.css
@@ -437,6 +437,16 @@ body {
   box-shadow: 0 1px 3px var(--executive-card-shadow);
 }
 
+.SigMemberOwner {
+  padding: 0.45rem 0.75rem;
+  border-radius: 9999px;
+  background: var(--color-text-body);
+  border: 1px solid var(--color-button-border);
+  color: var(--executive-card-bg);
+  font-weight: bold;
+  box-shadow: 0 1px 3px var(--executive-card-shadow);
+}
+
 .SigMembersEmpty {
   padding: 0.9rem 0.75rem;
   border-radius: 0.5rem;

--- a/src/components/header/HeaderRight.jsx
+++ b/src/components/header/HeaderRight.jsx
@@ -34,7 +34,7 @@ export default function HeaderRight({ user }) {
             id="HeaderUser"
             className="unset HeaderRight__user"
           >
-            <Image
+            <img
               src={user.profile_picture || '/main/default-pfp.png'}
               alt="Profile"
               className="user-profile-picture"


### PR DESCRIPTION
<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->

### What feature does this PR add?

- fixes #178 
- ig owner highlight
<img width="1162" height="242" alt="image" src="https://github.com/user-attachments/assets/afc894c5-e468-4b77-be4c-a2f28d5e7987" />
<img width="1169" height="234" alt="image" src="https://github.com/user-attachments/assets/ea7bd884-9b59-414d-b0ec-50380c07b49a" />

- hotfix: add google pfp image domain to config

---

### Are there any caveats or things to watch out for?

<!-- If none, write "None" -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Owners are highlighted and appear first in member lists on Pig and Sig pages.
  - Member lists preserve original order for non-owners.
- Style
  - New owner badge style applied in member lists.
  - Header spacing between right-side items increased to 1.5rem.
- Refactor
  - Profile avatar now uses standard image rendering with no expected visual change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->