### PR TITLE
:recycle: :zap: 시그, 피그 페이지 및 이미지 업로드 팝업 UI 수정

### DIFF
--- a/src/app/pig/[id]/EditPigButton.jsx
+++ b/src/app/pig/[id]/EditPigButton.jsx
@@ -11,7 +11,7 @@ export default function EditPigButton({ pigId, canEdit }) {
       onClick={() => router.push(`/pig/edit/${pigId}`)}
       type="button"
     >
-      내용 수정하기
+      수정하기
     </button>
   );
 }

--- a/src/app/pig/[id]/PigDeleteButton.jsx
+++ b/src/app/pig/[id]/PigDeleteButton.jsx
@@ -69,7 +69,7 @@ export default function PigDeleteButton({ pigId, canDelete, isOwner }) {
       disabled={pending}
       aria-busy={pending}
     >
-      {'피그 비활성화'}
+      {'비활성화'}
     </button>
   ) : null;
 }

--- a/src/app/pig/[id]/PigJoinLeaveButton.jsx
+++ b/src/app/pig/[id]/PigJoinLeaveButton.jsx
@@ -75,7 +75,7 @@ export default function PigJoinLeaveButton({ pigId, initialIsMember = false }) {
       disabled={pending}
       aria-busy={pending}
     >
-      {isMember ? '피그 탈퇴하기' : '피그 가입하기'}
+      {isMember ? '탈퇴하기' : '가입하기'}
     </button>
   );
 }

--- a/src/app/pig/[id]/page.css
+++ b/src/app/pig/[id]/page.css
@@ -1,6 +1,7 @@
 /* 페이지 전체 컨테이너 */
 .PigDetailContainer {
   max-width: 60vw;
+  min-width: 320px;
   margin: 1.5rem auto;
   padding: 1.5rem;
   border-radius: 1rem;
@@ -106,7 +107,7 @@ body {
   color: var(--color-text);
   font-weight: 600;
   line-height: 1;
-  min-width: 9rem; /* 초기 페인트 시 공간 확보 -> 레이아웃 점프 방지 */
+  min-width: 7rem; /* 초기 페인트 시 공간 확보 -> 레이아웃 점프 방지 */
   min-height: 2.5rem;
   transition:
     transform 120ms ease,
@@ -277,13 +278,13 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.55rem 0.9rem;
-  border-radius: 0.625rem;
-  background: var(--color-button-bg);
-  color: var(--color-button-text);
+  padding: 0.55rem 0.7rem;
+  border-radius: 0.9rem;
+  color: var(--color-button-bg);
+  background: var(--executive-card-bg);
   border: 1px solid var(--color-button-border);
-  font-weight: 600;
-  font-size: 0.95rem;
+  font-weight: 450;
+  font-size: 0.85rem;
   transition:
     transform 120ms ease,
     background-color 120ms ease,
@@ -293,8 +294,9 @@ body {
 }
 
 .PigButton:hover {
-  background: var(--color-button-hover-bg);
+  background: var(--color-button-bg);
   transform: translateY(-1px);
+  color: var(--color-button-text);
 }
 
 .PigButton:active {
@@ -318,12 +320,14 @@ body {
 }
 
 .PigButton.is-delete:not(:hover) {
-  background-color: var(--color-button-alert-bg);
+  color: var(--color-button-alert-bg);
   border-style: solid;
+  border-color: var(--color-button-alert-hover-bg);
 }
 
 .PigButton.is-delete:hover {
-  background-color: var(--color-button-alert-hover-bg);
+  background-color: var(--color-button-alert-bg);
+  color: var(--color-button-text);
   border-style: solid;
 }
 
@@ -335,20 +339,22 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background-color: var(--color-button-bg);
-  color: var(--color-button-text);
-  padding: 0.6rem 0.8rem;
-  border-radius: 0.5rem;
-  font-weight: 500;
+  color: var(--color-button-bg);
+  background-color: var(--executive-card-bg);
+  padding: 0.55rem 0.7rem;
+  border-radius: 0.9rem;
+  border: 1px solid var(--color-button-border);
+  font-weight: 450;
+  font-size: 0.85rem;
   cursor: pointer;
-  border: none;
   transition: background-color 0.2s ease;
   min-width: 0;
 }
 
 .PigMemberBtn:hover {
-  background-color: var(--color-button-hover-bg);
+  background-color: var(--color-button-bg);
   transform: translateY(-1px);
+  color: var(--color-button-text);
 }
 
 .PigMemberMenu {
@@ -373,10 +379,11 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.5rem 1rem;
+  padding: 0.3rem 0.8rem;
   background: transparent;
   border: none;
   text-align: center;
+  font-size: 0.85rem;
   color: var(--color-text-body);
   cursor: pointer;
   width: 100%;
@@ -396,20 +403,20 @@ body {
 
 @media (max-width: 560px) {
   .PigActionRow {
-    flex-direction: column;
+    flex-direction: row;
     align-items: stretch;
   }
   .PigButton {
     width: 100%;
-    max-width: 100%;
+    max-width: 5rem;
   }
   .PigMemberBtn {
     width: 100%;
-    max-width: 100%;
+    max-width: 7rem;
   }
   .PigMemberMenu {
     width: 100%;
-    max-width: 100%;
+    max-width: 7rem;
   }
 }
 

--- a/src/app/sig/[id]/EditSigButton.jsx
+++ b/src/app/sig/[id]/EditSigButton.jsx
@@ -11,7 +11,7 @@ export default function EditSigButton({ sigId, canEdit }) {
       onClick={() => router.push(`/sig/edit/${sigId}`)}
       type="button"
     >
-      내용 수정하기
+      수정하기
     </button>
   );
 }

--- a/src/app/sig/[id]/SigDeleteButton.jsx
+++ b/src/app/sig/[id]/SigDeleteButton.jsx
@@ -70,7 +70,7 @@ export default function SigDeleteButton({ sigId, canDelete, isOwner }) {
       disabled={pending}
       aria-busy={pending}
     >
-      {'시그 비활성화'}
+      {'비활성화'}
     </button>
   ) : null;
 }

--- a/src/app/sig/[id]/SigJoinLeaveButton.jsx
+++ b/src/app/sig/[id]/SigJoinLeaveButton.jsx
@@ -74,7 +74,7 @@ export default function SigJoinLeaveButton({ sigId, initialIsMember = false }) {
       disabled={pending}
       aria-busy={pending}
     >
-      {isMember ? '시그 탈퇴하기' : '시그 가입하기'}
+      {isMember ? '탈퇴하기' : '가입하기'}
     </button>
   );
 }

--- a/src/app/sig/[id]/page.css
+++ b/src/app/sig/[id]/page.css
@@ -1,6 +1,7 @@
 /* 페이지 전체 컨테이너 */
 .SigDetailContainer {
   max-width: 60vw;
+  min-width: 320px;
   margin: 1.5rem auto;
   padding: 1.5rem;
   border-radius: 1rem;
@@ -106,7 +107,7 @@ body {
   color: var(--color-text);
   font-weight: 600;
   line-height: 1;
-  min-width: 9rem; /* 초기 페인트 시 공간 확보 -> 레이아웃 점프 방지 */
+  min-width: 7rem; /* 초기 페인트 시 공간 확보 -> 레이아웃 점프 방지 */
   min-height: 2.5rem;
   transition:
     transform 120ms ease,
@@ -277,13 +278,13 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.55rem 0.9rem;
-  border-radius: 0.625rem;
-  background: var(--color-button-bg);
-  color: var(--color-button-text);
+  padding: 0.55rem 0.7rem;
+  border-radius: 0.9rem;
+  color: var(--color-button-bg);
+  background: var(--executive-card-bg);
   border: 1px solid var(--color-button-border);
-  font-weight: 600;
-  font-size: 0.95rem;
+  font-weight: 450;
+  font-size: 0.85rem;
   transition:
     transform 120ms ease,
     background-color 120ms ease,
@@ -293,8 +294,9 @@ body {
 }
 
 .SigButton:hover {
-  background: var(--color-button-hover-bg);
+  background: var(--color-button-bg);
   transform: translateY(-1px);
+  color: var(--color-button-text);
 }
 
 .SigButton:active {
@@ -318,12 +320,14 @@ body {
 }
 
 .SigButton.is-delete:not(:hover) {
-  background-color: var(--color-button-alert-bg);
+  color: var(--color-button-alert-bg);
   border-style: solid;
+  border-color: var(--color-button-alert-hover-bg);
 }
 
 .SigButton.is-delete:hover {
-  background-color: var(--color-button-alert-hover-bg);
+  background-color: var(--color-button-alert-bg);
+  color: var(--color-button-text);
   border-style: solid;
 }
 
@@ -335,20 +339,22 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background-color: var(--color-button-bg);
-  color: var(--color-button-text);
-  padding: 0.6rem 0.8rem;
-  border-radius: 0.5rem;
-  font-weight: 500;
+  color: var(--color-button-bg);
+  background-color: var(--executive-card-bg);
+  padding: 0.55rem 0.7rem;
+  border-radius: 0.9rem;
+  border: 1px solid var(--color-button-border);
+  font-weight: 450;
+  font-size: 0.85rem;
   cursor: pointer;
-  border: none;
   transition: background-color 0.2s ease;
   min-width: 0;
 }
 
 .SigMemberBtn:hover {
-  background-color: var(--color-button-hover-bg);
+  background-color: var(--color-button-bg);
   transform: translateY(-1px);
+  color: var(--color-button-text);
 }
 
 .SigMemberMenu {
@@ -373,10 +379,11 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.5rem 1rem;
+  padding: 0.3rem 0.8rem;
   background: transparent;
   border: none;
   text-align: center;
+  font-size: 0.85rem;
   color: var(--color-text-body);
   cursor: pointer;
   width: 100%;
@@ -396,20 +403,20 @@ body {
 
 @media (max-width: 560px) {
   .SigActionRow {
-    flex-direction: column;
+    flex-direction: row;
     align-items: stretch;
   }
   .SigButton {
     width: 100%;
-    max-width: 100%;
+    max-width: 5rem;
   }
   .SigMemberBtn {
     width: 100%;
-    max-width: 100%;
+    max-width: 7rem;
   }
   .SigMemberMenu {
     width: 100%;
-    max-width: 100%;
+    max-width: 7rem;
   }
 }
 

--- a/src/components/board/editor.module.css
+++ b/src/components/board/editor.module.css
@@ -8,3 +8,10 @@
   box-sizing: border-box;
   cursor: text;
 }
+
+.mdxeditor [role='dialog'] input,
+.mdxeditor [role='dialog'] textarea {
+  min-height: unset;
+  padding: 6px;
+  width: auto;
+}


### PR DESCRIPTION
<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->

### What feature does this PR add?

<!-- Describe the feature or enhancement you implemented -->

시그/피그 페이지의 min-width 설정 후 토글 버튼 디자인을 조금 더 간결하게 바꾸었습니다. 아래는 PC 뷰와 모바일 뷰에서 새 버튼이 어떻게 보이는지 스크린샷입니다.

PC 뷰 시그 페이지 (맨 앞 탈퇴하기 버튼은 커서를 올려놓았을 때의 모습입니다)

<img width="2560" height="1360" alt="스크린샷(1662)" src="https://github.com/user-attachments/assets/ae3e2124-2128-4d23-ba70-f0df66076455" />
<img width="2560" height="1384" alt="스크린샷(1663)" src="https://github.com/user-attachments/assets/aa9c9e3c-87f8-4320-9cea-76047f521bde" />


PC 뷰 피그 페이지  (맨 앞 탈퇴하기 버튼은 커서를 올려놓았을 때의 모습입니다)

<img width="2560" height="1359" alt="스크린샷(1668)" src="https://github.com/user-attachments/assets/12a64544-944e-42ed-a1fe-d5f76423ad50" />
<img width="2559" height="1407" alt="스크린샷(1669)" src="https://github.com/user-attachments/assets/0e72a321-7eed-46f1-9651-f5a9df7a8777" />


모바일 뷰 시그 페이지

<img width="511" height="1274" alt="스크린샷(1665)" src="https://github.com/user-attachments/assets/920b38ad-58e0-4f28-bdc0-b9b98a3e5c5c" />
<img width="520" height="1266" alt="스크린샷(1664)" src="https://github.com/user-attachments/assets/1520e127-0617-4877-a9f1-ac2a09484d03" />

모바일 뷰 피그 페이지

<img width="543" height="1310" alt="스크린샷(1667)" src="https://github.com/user-attachments/assets/f87fce19-4ab0-4aef-8507-15b0ed16bd65" />
<img width="497" height="1247" alt="스크린샷(1666)" src="https://github.com/user-attachments/assets/fecd94ef-41ed-4e2f-a358-b007bf5b0fb4" />


또한, 게시판에서 이미지 업로드할 때 이미지 업로드창에서 text input field가 벗어나는 문제를 해결했습니다.

<img width="2560" height="1369" alt="스크린샷(1661)" src="https://github.com/user-attachments/assets/43a88eab-f557-497d-9497-894746485743" />

fixes #336  
fixes #329
fixes #333

### Are there any caveats or things to watch out for?

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified button labels across management interfaces for improved clarity.
  * Refined action button styling with updated spacing, colors, and hover states.
  * Enhanced responsive design for detail page layouts across screen sizes.
  * Improved editor dialog input field styling for better usability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->