### PR TITLE
⚡ sig/pig owner marked in executive page

### DIFF
--- a/src/app/executive/pig/PigList.jsx
+++ b/src/app/executive/pig/PigList.jsx
@@ -118,6 +118,148 @@ const getLeaderUserId = (pig) => {
   return String(pig.owner);
 };
 
+const renderPigRow = (pig, ctx) => {
+  const pigIdStr = String(pig.id);
+  const ownerIdStr = pig?.owner != null ? String(pig.owner) : '';
+  const members = Array.isArray(pig?.members) ? pig.members : [];
+  const leaderId = getLeaderUserId(pig);
+  const selected = ctx.selectedMemberByPigId[pigIdStr] ?? leaderId;
+
+  return (
+    <tr key={pig.id} className={styles['adm-tr']}>
+      <td className={styles['adm-td']}>{pig.id}</td>
+
+      <td className={styles['adm-td']}>
+        <input
+          className={styles['adm-input']}
+          value={pig.title ?? ''}
+          onChange={(e) => ctx.updatePigField(pig.id, 'title', e.target.value)}
+        />
+      </td>
+
+      <td className={styles['adm-td']}>
+        <input
+          className={styles['adm-input']}
+          value={pig.description ?? ''}
+          onChange={(e) => ctx.updatePigField(pig.id, 'description', e.target.value)}
+        />
+      </td>
+
+      <td className={styles['adm-td']}>
+        <input
+          className={styles['adm-input']}
+          value={pig.content ?? ''}
+          onChange={(e) => ctx.updatePigField(pig.id, 'content', e.target.value)}
+        />
+      </td>
+
+      <td className={styles['adm-td']}>
+        <select
+          className={styles['adm-select']}
+          value={pig.status ?? ''}
+          onChange={(e) => ctx.updatePigField(pig.id, 'status', e.target.value)}
+        >
+          {Object.keys(STATUS_MAP).map((key) => (
+            <option key={key} value={key}>
+              {STATUS_MAP[key]}
+            </option>
+          ))}
+        </select>
+      </td>
+
+      <td className={styles['adm-td']}>
+        <input
+          className={styles['adm-input']}
+          value={pig.year ?? ''}
+          onChange={(e) => ctx.updatePigField(pig.id, 'year', e.target.value)}
+        />
+      </td>
+
+      <td className={styles['adm-td']}>
+        <select
+          className={styles['adm-select']}
+          value={pig.semester ?? ''}
+          onChange={(e) => ctx.updatePigField(pig.id, 'semester', e.target.value)}
+        >
+          {Object.keys(SEMESTER_MAP).map((key) => (
+            <option key={key} value={key}>
+              {SEMESTER_MAP[key]}학기
+            </option>
+          ))}
+        </select>
+      </td>
+
+      <td className={styles['adm-td']}>
+        <select
+          className={`${styles['adm-select']} ${styles['adm-select-bool']}`}
+          value={String(Boolean(pig.should_extend))}
+          onChange={(e) =>
+            ctx.updatePigField(pig.id, 'should_extend', e.target.value === 'true')
+          }
+        >
+          <option value="true">예</option>
+          <option value="false">아니오</option>
+        </select>
+      </td>
+
+      <td className={styles['adm-td']}>
+        <select
+          className={`${styles['adm-select']} ${styles['adm-select-bool']} ${styles['adm-select-bool-wide']}`}
+          value={String(Boolean(pig.is_rolling_admission))}
+          onChange={(e) =>
+            ctx.updatePigField(pig.id, 'is_rolling_admission', e.target.value === 'true')
+          }
+        >
+          <option value="true">예</option>
+          <option value="false">아니오</option>
+        </select>
+      </td>
+
+      <td className={styles['adm-td']}>
+        <select
+          className={styles['adm-select']}
+          value={selected || ''}
+          onChange={(e) =>
+            ctx.setSelectedMemberByPigId((prev) => ({
+              ...prev,
+              [pigIdStr]: e.target.value,
+            }))
+          }
+        >
+          {members.length === 0 ? <option value="">(없음)</option> : null}
+          {members.map((m, idx) => {
+            const mid = m?.user_id != null ? String(m.user_id) : '';
+            const name = m?.user?.name ?? '';
+            const label = mid && mid === ownerIdStr ? `[PIG장] ${name}` : name;
+            return (
+              <option key={`${pigIdStr}-${mid || name}-${idx}`} value={mid}>
+                {label}
+              </option>
+            );
+          })}
+        </select>
+      </td>
+
+      <td className={styles['adm-td']}>
+        <button
+          className={styles['adm-button']}
+          onClick={() => ctx.handleSave(pig)}
+          disabled={Boolean(ctx.saving[pig.id])}
+        >
+          저장
+        </button>
+        <button
+          className={styles['adm-button']}
+          onClick={() => ctx.handleDelete(pig.id)}
+          disabled={Boolean(ctx.saving[pig.id])}
+        >
+          삭제
+        </button>
+      </td>
+    </tr>
+  );
+};
+
 export default function PigList({ pigs: pigsDefault }) {
   const [pigs, setPigs] = useState(pigsDefault ?? []);
   const [filteredPigs, setFilteredPigs] = useState(pigsDefault ?? []);
@@ -219,144 +361,13 @@ export default function PigList({ pigs: pigsDefault }) {
     }
   };
 
-  const renderPigRow = (pig) => {
-    const pigIdStr = String(pig.id);
-    const ownerIdStr = pig?.owner != null ? String(pig.owner) : '';
-    const members = Array.isArray(pig?.members) ? pig.members : [];
-    const leaderId = getLeaderUserId(pig);
-    const selected = selectedMemberByPigId[pigIdStr] ?? leaderId;
-
-    return (
-      <tr key={pig.id} className={styles['adm-tr']}>
-        <td className={styles['adm-td']}>{pig.id}</td>
-
-        <td className={styles['adm-td']}>
-          <input
-            className={styles['adm-input']}
-            value={pig.title ?? ''}
-            onChange={(e) => updatePigField(pig.id, 'title', e.target.value)}
-          />
-        </td>
-
-        <td className={styles['adm-td']}>
-          <input
-            className={styles['adm-input']}
-            value={pig.description ?? ''}
-            onChange={(e) => updatePigField(pig.id, 'description', e.target.value)}
-          />
-        </td>
-
-        <td className={styles['adm-td']}>
-          <input
-            className={styles['adm-input']}
-            value={pig.content ?? ''}
-            onChange={(e) => updatePigField(pig.id, 'content', e.target.value)}
-          />
-        </td>
-
-        <td className={styles['adm-td']}>
-          <select
-            className={styles['adm-select']}
-            value={pig.status ?? ''}
-            onChange={(e) => updatePigField(pig.id, 'status', e.target.value)}
-          >
-            {Object.keys(STATUS_MAP).map((key) => (
-              <option key={key} value={key}>
-                {STATUS_MAP[key]}
-              </option>
-            ))}
-          </select>
-        </td>
-
-        <td className={styles['adm-td']}>
-          <input
-            className={styles['adm-input']}
-            value={pig.year ?? ''}
-            onChange={(e) => updatePigField(pig.id, 'year', e.target.value)}
-          />
-        </td>
-
-        <td className={styles['adm-td']}>
-          <select
-            className={styles['adm-select']}
-            value={pig.semester ?? ''}
-            onChange={(e) => updatePigField(pig.id, 'semester', e.target.value)}
-          >
-            {Object.keys(SEMESTER_MAP).map((key) => (
-              <option key={key} value={key}>
-                {SEMESTER_MAP[key]}학기
-              </option>
-            ))}
-          </select>
-        </td>
-
-        <td className={styles['adm-td']}>
-          <select
-            className={`${styles['adm-select']} ${styles['adm-select-bool']}`}
-            value={String(Boolean(pig.should_extend))}
-            onChange={(e) => updatePigField(pig.id, 'should_extend', e.target.value === 'true')}
-          >
-            <option value="true">예</option>
-            <option value="false">아니오</option>
-          </select>
-        </td>
-
-        <td className={styles['adm-td']}>
-          <select
-            className={`${styles['adm-select']} ${styles['adm-select-bool']} ${styles['adm-select-bool-wide']}`}
-            value={String(Boolean(pig.is_rolling_admission))}
-            onChange={(e) =>
-              updatePigField(pig.id, 'is_rolling_admission', e.target.value === 'true')
-            }
-          >
-            <option value="true">예</option>
-            <option value="false">아니오</option>
-          </select>
-        </td>
-
-        <td className={styles['adm-td']}>
-          <select
-            className={styles['adm-select']}
-            value={selected || ''}
-            onChange={(e) =>
-              setSelectedMemberByPigId((prev) => ({
-                ...prev,
-                [pigIdStr]: e.target.value,
-              }))
-            }
-          >
-            {members.length === 0 ? <option value="">(없음)</option> : null}
-            {members.map((m) => {
-              const mid = m?.user_id != null ? String(m.user_id) : '';
-              const name = m?.user?.name ?? '';
-              const label = mid && mid === ownerIdStr ? `[PIG장] ${name}` : name;
-              return (
-                <option key={mid || name} value={mid}>
-                  {label}
-                </option>
-              );
-            })}
-          </select>
-        </td>
-
-        <td className={styles['adm-td']}>
-          <button
-            className={styles['adm-button']}
-            onClick={() => handleSave(pig)}
-            disabled={Boolean(saving[pig.id])}
-          >
-            저장
-          </button>
-          <button
-            className={styles['adm-button']}
-            onClick={() => handleDelete(pig.id)}
-            disabled={Boolean(saving[pig.id])}
-          >
-            삭제
-          </button>
-        </td>
-      </tr>
-    );
+  const rowCtx = {
+    saving,
+    selectedMemberByPigId,
+    setSelectedMemberByPigId,
+    updatePigField,
+    handleSave,
+    handleDelete,
   };
 
   return (
@@ -391,7 +402,7 @@ export default function PigList({ pigs: pigsDefault }) {
           </tr>
           <PigFilterRow filter={filter} updateFilterCriteria={updateFilterCriteria} />
         </thead>
-        <tbody>{filteredPigs.map(renderPigRow)}</tbody>
+        <tbody>{filteredPigs.map((pig) => renderPigRow(pig, rowCtx))}</tbody>
       </table>
     </div>
   );

--- a/src/app/executive/sig/SigList.jsx
+++ b/src/app/executive/sig/SigList.jsx
@@ -118,6 +118,148 @@ const getLeaderUserId = (sig) => {
   return String(sig.owner);
 };
 
+const renderSigRow = (sig, ctx) => {
+  const sigIdStr = String(sig.id);
+  const ownerIdStr = sig?.owner != null ? String(sig.owner) : '';
+  const members = Array.isArray(sig?.members) ? sig.members : [];
+  const leaderId = getLeaderUserId(sig);
+  const selected = ctx.selectedMemberBySigId[sigIdStr] ?? leaderId;
+
+  return (
+    <tr key={sig.id} className={styles['adm-tr']}>
+      <td className={styles['adm-td']}>{sig.id}</td>
+
+      <td className={styles['adm-td']}>
+        <input
+          className={styles['adm-input']}
+          value={sig.title ?? ''}
+          onChange={(e) => ctx.updateSigField(sig.id, 'title', e.target.value)}
+        />
+      </td>
+
+      <td className={styles['adm-td']}>
+        <input
+          className={styles['adm-input']}
+          value={sig.description ?? ''}
+          onChange={(e) => ctx.updateSigField(sig.id, 'description', e.target.value)}
+        />
+      </td>
+
+      <td className={styles['adm-td']}>
+        <input
+          className={styles['adm-input']}
+          value={sig.content ?? ''}
+          onChange={(e) => ctx.updateSigField(sig.id, 'content', e.target.value)}
+        />
+      </td>
+
+      <td className={styles['adm-td']}>
+        <select
+          className={styles['adm-select']}
+          value={sig.status ?? ''}
+          onChange={(e) => ctx.updateSigField(sig.id, 'status', e.target.value)}
+        >
+          {Object.keys(STATUS_MAP).map((key) => (
+            <option key={key} value={key}>
+              {STATUS_MAP[key]}
+            </option>
+          ))}
+        </select>
+      </td>
+
+      <td className={styles['adm-td']}>
+        <input
+          className={styles['adm-input']}
+          value={sig.year ?? ''}
+          onChange={(e) => ctx.updateSigField(sig.id, 'year', e.target.value)}
+        />
+      </td>
+
+      <td className={styles['adm-td']}>
+        <select
+          className={styles['adm-select']}
+          value={sig.semester ?? ''}
+          onChange={(e) => ctx.updateSigField(sig.id, 'semester', e.target.value)}
+        >
+          {Object.keys(SEMESTER_MAP).map((key) => (
+            <option key={key} value={key}>
+              {SEMESTER_MAP[key]}학기
+            </option>
+          ))}
+        </select>
+      </td>
+
+      <td className={styles['adm-td']}>
+        <select
+          className={`${styles['adm-select']} ${styles['adm-select-bool']}`}
+          value={String(Boolean(sig.should_extend))}
+          onChange={(e) =>
+            ctx.updateSigField(sig.id, 'should_extend', e.target.value === 'true')
+          }
+        >
+          <option value="true">예</option>
+          <option value="false">아니오</option>
+        </select>
+      </td>
+
+      <td className={styles['adm-td']}>
+        <select
+          className={`${styles['adm-select']} ${styles['adm-select-bool']} ${styles['adm-select-bool-wide']}`}
+          value={String(Boolean(sig.is_rolling_admission))}
+          onChange={(e) =>
+            ctx.updateSigField(sig.id, 'is_rolling_admission', e.target.value === 'true')
+          }
+        >
+          <option value="true">예</option>
+          <option value="false">아니오</option>
+        </select>
+      </td>
+
+      <td className={styles['adm-td']}>
+        <select
+          className={styles['adm-select']}
+          value={selected || ''}
+          onChange={(e) =>
+            ctx.setSelectedMemberBySigId((prev) => ({
+              ...prev,
+              [sigIdStr]: e.target.value,
+            }))
+          }
+        >
+          {members.length === 0 ? <option value="">(없음)</option> : null}
+          {members.map((m, idx) => {
+            const mid = m?.user_id != null ? String(m.user_id) : '';
+            const name = m?.user?.name ?? '';
+            const label = mid && mid === ownerIdStr ? `[SIG장] ${name}` : name;
+            return (
+              <option key={`${sigIdStr}-${mid || name}-${idx}`} value={mid}>
+                {label}
+              </option>
+            );
+          })}
+        </select>
+      </td>
+
+      <td className={styles['adm-td']}>
+        <button
+          className={styles['adm-button']}
+          onClick={() => ctx.handleSave(sig)}
+          disabled={Boolean(ctx.saving[sig.id])}
+        >
+          저장
+        </button>
+        <button
+          className={styles['adm-button']}
+          onClick={() => ctx.handleDelete(sig.id)}
+          disabled={Boolean(ctx.saving[sig.id])}
+        >
+          삭제
+        </button>
+      </td>
+    </tr>
+  );
+};
+
 export default function SigList({ sigs: sigsDefault }) {
   const [sigs, setSigs] = useState(sigsDefault ?? []);
   const [filteredSigs, setFilteredSigs] = useState(sigsDefault ?? []);
@@ -219,144 +361,13 @@ export default function SigList({ sigs: sigsDefault }) {
     }
   };
 
-  const renderSigRow = (sig) => {
-    const sigIdStr = String(sig.id);
-    const ownerIdStr = sig?.owner != null ? String(sig.owner) : '';
-    const members = Array.isArray(sig?.members) ? sig.members : [];
-    const leaderId = getLeaderUserId(sig);
-    const selected = selectedMemberBySigId[sigIdStr] ?? leaderId;
-
-    return (
-      <tr key={sig.id} className={styles['adm-tr']}>
-        <td className={styles['adm-td']}>{sig.id}</td>
-
-        <td className={styles['adm-td']}>
-          <input
-            className={styles['adm-input']}
-            value={sig.title ?? ''}
-            onChange={(e) => updateSigField(sig.id, 'title', e.target.value)}
-          />
-        </td>
-
-        <td className={styles['adm-td']}>
-          <input
-            className={styles['adm-input']}
-            value={sig.description ?? ''}
-            onChange={(e) => updateSigField(sig.id, 'description', e.target.value)}
-          />
-        </td>
-
-        <td className={styles['adm-td']}>
-          <input
-            className={styles['adm-input']}
-            value={sig.content ?? ''}
-            onChange={(e) => updateSigField(sig.id, 'content', e.target.value)}
-          />
-        </td>
-
-        <td className={styles['adm-td']}>
-          <select
-            className={styles['adm-select']}
-            value={sig.status ?? ''}
-            onChange={(e) => updateSigField(sig.id, 'status', e.target.value)}
-          >
-            {Object.keys(STATUS_MAP).map((key) => (
-              <option key={key} value={key}>
-                {STATUS_MAP[key]}
-              </option>
-            ))}
-          </select>
-        </td>
-
-        <td className={styles['adm-td']}>
-          <input
-            className={styles['adm-input']}
-            value={sig.year ?? ''}
-            onChange={(e) => updateSigField(sig.id, 'year', e.target.value)}
-          />
-        </td>
-
-        <td className={styles['adm-td']}>
-          <select
-            className={styles['adm-select']}
-            value={sig.semester ?? ''}
-            onChange={(e) => updateSigField(sig.id, 'semester', e.target.value)}
-          >
-            {Object.keys(SEMESTER_MAP).map((key) => (
-              <option key={key} value={key}>
-                {SEMESTER_MAP[key]}학기
-              </option>
-            ))}
-          </select>
-        </td>
-
-        <td className={styles['adm-td']}>
-          <select
-            className={`${styles['adm-select']} ${styles['adm-select-bool']}`}
-            value={String(Boolean(sig.should_extend))}
-            onChange={(e) => updateSigField(sig.id, 'should_extend', e.target.value === 'true')}
-          >
-            <option value="true">예</option>
-            <option value="false">아니오</option>
-          </select>
-        </td>
-
-        <td className={styles['adm-td']}>
-          <select
-            className={`${styles['adm-select']} ${styles['adm-select-bool']} ${styles['adm-select-bool-wide']}`}
-            value={String(Boolean(sig.is_rolling_admission))}
-            onChange={(e) =>
-              updateSigField(sig.id, 'is_rolling_admission', e.target.value === 'true')
-            }
-          >
-            <option value="true">예</option>
-            <option value="false">아니오</option>
-          </select>
-        </td>
-
-        <td className={styles['adm-td']}>
-          <select
-            className={styles['adm-select']}
-            value={selected || ''}
-            onChange={(e) =>
-              setSelectedMemberBySigId((prev) => ({
-                ...prev,
-                [sigIdStr]: e.target.value,
-              }))
-            }
-          >
-            {members.length === 0 ? <option value="">(없음)</option> : null}
-            {members.map((m) => {
-              const mid = m?.user_id != null ? String(m.user_id) : '';
-              const name = m?.user?.name ?? '';
-              const label = mid && mid === ownerIdStr ? `[SIG장] ${name}` : name;
-              return (
-                <option key={mid || name} value={mid}>
-                  {label}
-                </option>
-              );
-            })}
-          </select>
-        </td>
-
-        <td className={styles['adm-td']}>
-          <button
-            className={styles['adm-button']}
-            onClick={() => handleSave(sig)}
-            disabled={Boolean(saving[sig.id])}
-          >
-            저장
-          </button>
-          <button
-            className={styles['adm-button']}
-            onClick={() => handleDelete(sig.id)}
-            disabled={Boolean(saving[sig.id])}
-          >
-            삭제
-          </button>
-        </td>
-      </tr>
-    );
+  const rowCtx = {
+    saving,
+    selectedMemberBySigId,
+    setSelectedMemberBySigId,
+    updateSigField,
+    handleSave,
+    handleDelete,
   };
 
   return (
@@ -391,7 +402,7 @@ export default function SigList({ sigs: sigsDefault }) {
           </tr>
           <SigFilterRow filter={filter} updateFilterCriteria={updateFilterCriteria} />
         </thead>
-        <tbody>{filteredSigs.map(renderSigRow)}</tbody>
+        <tbody>{filteredSigs.map((sig) => renderSigRow(sig, rowCtx))}</tbody>
       </table>
     </div>
   );


### PR DESCRIPTION

<img width="541" height="330" alt="image" src="https://github.com/user-attachments/assets/335b19fd-9774-4e59-9c7d-8339d8d45448" />
sig/pig executive page에서, 구성원 목록중 시그장/피그장이 기본으로 나오고, 시그장/피그장은 옆에 시그장/피그장이라고 뜨게 해놨습니다.

<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->

### What feature does this PR add?

<!-- Describe the feature or enhancement you implemented -->

---

### Are there any caveats or things to watch out for?

<!-- If none, write "None" -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline, per-item editable rows for pigs and sigs with fields for title, description, content, status, year, semester, boolean flags, member selector, and per-row Save/Delete actions.

* **Bug Fixes**
  * More robust filtering and member matching with safer handling of missing data.
  * Improved save/delete flows with clearer network error messages and consistent boolean handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->