### PR TITLE
⚡다크모드 alert 버튼 명도 대비 개선

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -82,7 +82,6 @@ html.theme-animating {
   --color-button-border: #2f4f67;
   --color-button-hover-bg: #368aa0;
   --color-button-alert-bg: #ff3333;
-  --color-button-alert-hover-bg: #ff3333;
   --color-button-text: white;
   --color-text-body: #f5f5f5;
   --color-text-subtle: #aaaaaa;


### PR DESCRIPTION
<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->

### What feature does this PR add?

<!-- Describe the feature or enhancement you implemented -->
--- 다크모드에서 alert 버튼(비활성화)의 텍스트/보더 색상을 #FF0000에서 #FF3333으로 변경하여 명도 대비를 4.12:1에서 4.5:1 이상으로 개선 

### Are there any caveats or things to watch out for?

<!-- If none, write "None" -->
None

fix #427 
<변경전>
<img width="853" height="398" alt="test3" src="https://github.com/user-attachments/assets/b3d970fb-ecc4-44a2-a081-891f3f6f687c" />
<img width="757" height="405" alt="test4" src="https://github.com/user-attachments/assets/5cd144f1-8954-4911-b70d-9dcf857a7280" />

<변경후>
<img width="693" height="392" alt="test1" src="https://github.com/user-attachments/assets/615b444c-8e1c-495a-8997-d58abf7f8616" />
<img width="758" height="408" alt="test2" src="https://github.com/user-attachments/assets/b5c77c91-86ff-412d-a503-3f179416f1df" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added an explicit dark-mode alert button background color to ensure consistent alert button appearance and predictable hover behavior in the dark theme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->