### PR TITLE
🐛 burger icon 정렬 수정

### DIFF
--- a/src/components/header/MobileMenuList.jsx
+++ b/src/components/header/MobileMenuList.jsx
@@ -52,7 +52,9 @@ export default function MobileMenuList() {
         className={styles.hamburgerButton}
         onClick={() => setMobileMenuOpen((prev) => !prev)}
       >
-        ☰
+        <span className="material-icons" style={{ fontSize: 'inherit' }}>
+          menu
+        </span>
       </button>
 
       <div id="mobileMenuPanel" className={wrapperClass}>


### PR DESCRIPTION
<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->

### What feature does this PR add?

<!-- Describe the feature or enhancement you implemented -->
모바일 hamburger 버튼의 아이콘 정렬 문제를 수정했습니다.

☰ 텍스트 문자를 Material Icons의 menu으로 교체했습니다.
☰은 텍스트 문자이기 때문에 OS별 폰트 fallback에 따라 렌더링이 달라지는 문제가 있었습니다 (macOS/Windows). 이미 로드 중인 Material Icons를 활용하여 해결했습니다.

<img width="62" height="60" alt="image" src="https://github.com/user-attachments/assets/155e74d7-8ba4-426c-a483-5a64107f22fd" />


fix #460 

---

### Are there any caveats or things to watch out for?

<!-- If none, write "None" -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the mobile menu button icon design for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->