### PR TITLE
임원진 페이지 SIG 관리 테이블 가로 스크롤 추가

### DIFF
--- a/src/app/executive/sig/SigList.jsx
+++ b/src/app/executive/sig/SigList.jsx
@@ -97,37 +97,37 @@ export default function SigList({ sigs }) {
     return sigs.filter(matches);
   }, [sigs, filter]);
 
-  	return (
-	  <div className={styles['adm-table-wrap']}>
-	    <table className={styles['adm-table']}>
-	      <colgroup>
-	        <col />
-	        <col />
-	        <col />
-	        <col />
-	        <col />
-	        <col />
-	      </colgroup>
-	      <thead>
-	        <tr className={styles['adm-tr']}>
-	          <th className={styles['adm-th']}>이름</th>
-	          <th className={styles['adm-th']}>상태</th>
-	          <th className={styles['adm-th']}>연도</th>
-	          <th className={styles['adm-th']}>학기</th>
-	          <th className={styles['adm-th']}>SIG장</th>
-	          <th className={styles['adm-th']}>상세보기</th>
-	        </tr>
-	        <SigFilterRow
-	          filter={filter}
-	          updateFilterCriteria={(field, value) => setFilter({ ...filter, [field]: value })}
-	        />
-	      </thead>
-	      <tbody>
-	        {filteredSigs.map((sig) => (
-	          <RenderSigRow sig={sig} key={sig.id} />
-	        ))}
-	      </tbody>
-	    </table>
-	  </div>
-	);
+  return (
+    <div className={styles['adm-table-wrap']}>
+      <table className={styles['adm-table']}>
+        <colgroup>
+          <col />
+          <col />
+          <col />
+          <col />
+          <col />
+          <col />
+        </colgroup>
+        <thead>
+          <tr className={styles['adm-tr']}>
+            <th className={styles['adm-th']}>이름</th>
+            <th className={styles['adm-th']}>상태</th>
+            <th className={styles['adm-th']}>연도</th>
+            <th className={styles['adm-th']}>학기</th>
+            <th className={styles['adm-th']}>SIG장</th>
+            <th className={styles['adm-th']}>상세보기</th>
+          </tr>
+          <SigFilterRow
+            filter={filter}
+            updateFilterCriteria={(field, value) => setFilter({ ...filter, [field]: value })}
+          />
+        </thead>
+        <tbody>
+          {filteredSigs.map((sig) => (
+            <RenderSigRow sig={sig} key={sig.id} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
 }


### PR DESCRIPTION
### What feature does this PR add?

임원진 페이지의 SIG 관리 테이블을 `adm-table-wrap`으로 감싸
테이블 내부에서 가로 스크롤이 가능하도록 수정했습니다.

---

### Are there any caveats or things to watch out for?

없음

fixed #468


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Wrapped the signature list table in an updated styling container to refine layout, spacing, and visual structure. This is a purely presentational change—table content, filtering, and row behavior remain unchanged. The update improves readability and consistency of the signature list UI without altering functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->