### PR TITLE
⚡배너의 z-index 수정 #422

### DIFF
--- a/src/app/Footer.module.css
+++ b/src/app/Footer.module.css
@@ -2,7 +2,7 @@
   width: 100%;
   background: var(--footer-background);
   color: var(--footer-text-color);
-  z-index: 10000;
+  z-index: 500;
   border-top: 1px solid rgba(255, 255, 255, 0.1);
   overflow-x: hidden;
 }

--- a/src/app/sig/[id]/page.css
+++ b/src/app/sig/[id]/page.css
@@ -9,6 +9,8 @@
   background-color: var(--executive-card-bg);
   user-select: text;
   -webkit-user-select: text;
+  position: relative;
+  z-index: 600;
 }
 .SigDetailContainer,
 .SigDetailContainer * {
@@ -373,7 +375,7 @@ body {
   border-radius: 0.625rem;
   overflow: hidden;
   padding: 0.4rem 0.5rem;
-  z-index: 10;
+  z-index: 100;
 }
 
 .SigMemberMenu.open {


### PR DESCRIPTION
<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->

### What feature does this PR add?

<!-- Describe the feature or enhancement you implemented -->

---

시그장 양도 드랍다운의 z-index와 Footer의 z-index를 수정하여 시그장 양도 드랍다운의 위치를 Footer 위로 오도록 하였습니다. 

### Are there any caveats or things to watch out for?

<!-- If none, write "None" -->
None
Fix #422 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Adjusted visual layering and z-index values for the footer and signature detail components to ensure proper element stacking order and improved menu dropdown visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->