### PR TITLE
♻️ about/welcome 버튼 디자인 개선

### DIFF
--- a/src/app/about/about.module.css
+++ b/src/app/about/about.module.css
@@ -617,7 +617,7 @@
   flex-wrap: wrap;
 }
 
-.button {
+.linkButton {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -644,17 +644,17 @@
   box-shadow: 0 4px 14px var(--button-shadow, rgba(0, 0, 0, 0.12)); /* ✅ 더 선명 */
 }
 
-.button:hover {
+.linkButton:hover {
   background-color: var(--color-button-hover-bg);
   box-shadow: 0 8px 22px var(--button-shadow, rgba(0, 0, 0, 0.16));
   transform: translateY(-1px);
 }
 
-.button:active {
+.linkButton:active {
   transform: translateY(1px);
 }
 
-.button:focus-visible {
+.linkButton:focus-visible {
   outline: 3px solid rgba(59, 130, 246, 0.45);
   outline-offset: 2px;
 }
@@ -663,7 +663,7 @@
   .buttonsContainer {
     gap: 0.5rem;
   }
-  .buttonsContainer .button {
+  .buttonsContainer .linkButton {
     flex: 1 1 100%;
     width: 100%;
   }

--- a/src/app/about/welcome/page.jsx
+++ b/src/app/about/welcome/page.jsx
@@ -89,7 +89,7 @@ export default async function WelcomePage() {
                 href={KAKAO_INVITE_LINK}
                 target="_blank"
                 rel="noopener noreferrer"
-                className={styles.button}
+                className={styles.linkButton}
               >
                 카카오톡 팀 채팅방 입장
               </a>
@@ -122,7 +122,7 @@ export default async function WelcomePage() {
                 href={DISCORD_INVITE_LINK}
                 target="_blank"
                 rel="noopener noreferrer"
-                className={styles.button}
+                className={styles.linkButton}
               >
                 디스코드 서버 입장
               </a>
@@ -137,7 +137,7 @@ export default async function WelcomePage() {
               입금 확인과 가입 승인 상태는 <strong>마이페이지</strong>에서 확인할 수 있어요.
             </p>
             <div className={styles.buttonsContainer}>
-              <a href="/about/my-page" className={styles.button}>
+              <a href="/about/my-page" className={styles.linkButton}>
                 마이페이지 열기
               </a>
             </div>


### PR DESCRIPTION
<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->

### What feature does this PR add?

<!-- Describe the feature or enhancement you implemented -->

fixed #501 
<img width="1371" height="1098" alt="image" src="https://github.com/user-attachments/assets/ced3b1c6-d783-414a-9b45-e5be6869c544" />
about.module.css에서 마이페이지 열기 버튼에 쓰던 actionButton과 디스코드 서버 입장 버튼과 카카오톡 팀 채팅방 입장 버튼에 쓰던 chatButton을 button으로 통합하였습니다.

---

### Are there any caveats or things to watch out for?

<!-- If none, write "None" -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * About page button styles updated: removed an obsolete button variant, consolidated chat/action buttons into a single "link" style, and adjusted responsive rules so buttons display consistently on small screens.
  * Anchor links on the Welcome page (invite and profile links) now use the unified link styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->