### PR TITLE
⚡ ex-developer section

### DIFF
--- a/src/app/about/developers/client.jsx
+++ b/src/app/about/developers/client.jsx
@@ -2,105 +2,112 @@
 
 import Image from 'next/image';
 import { useSwipeable } from 'react-swipeable';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import styles from '../about.module.css';
 import developerStyles from './developers.module.css';
 
-const developers = [
+const executives = [
   {
     name: '강명석',
     image: '/devs/kms.jpg',
     description: 'init 정상화해줬잖아 기능정의도해줬잖아 그냥 다해줬잖아',
-    activeTerms: ['25-1', '25-S', '25-2', '25-W', '26-1'],
   },
   {
     name: '이한경',
     image: '/devs/lhk.jpg',
     description: '한경님의 백엔드 너무 좋아앗',
-    activeTerms: ['25-1', '25-S', '25-2', '25-W', '26-1'],
   },
   {
     name: '박성현',
     image: '/devs/psh.jpg',
     description: '아주아주 귀여운 여고생',
-    activeTerms: ['25-1', '25-S', '25-2', '25-W', '26-1'],
-  },
-  {
-    name: '박상혁',
-    image: '/devs/psh.jpg',
-    description: 'SCSC 막스 베르슈타펜',
-    activeTerms: ['25-2', '25-W'],
   },
   {
     name: '최정원',
     image: '',
     description: '',
-    activeTerms: ['25-2', '25-W', '26-1'],
   },
   {
     name: '이태윤',
     image: '',
     description: '',
-    activeTerms: ['25-2', '25-W', '26-1'],
-  },
-  {
-    name: '황민기',
-    image: '/devs/hmk.jpg',
-    description: '커밋주작은뭐야',
-    activeTerms: ['25-1', '25-S'],
-  },
-  {
-    name: '윤영우',
-    image: '/devs/yyw.jpg',
-    description: '고능',
-    activeTerms: ['25-S', '25-2'],
   },
 ];
 
-function formatTerm(year, semester) {
-  const shortYear = String(year).slice(-2);
-
-  switch (semester) {
-    case 1:
-      return `${shortYear}-1`;
-    case 2:
-      return `${shortYear}-S`;
-    case 3:
-      return `${shortYear}-2`;
-    case 4:
-      return `${shortYear}-W`;
-    default:
-      return null;
-  }
-}
-
-function parseTerm(term) {
-  const [yearPart, semesterPart] = term.split('-');
-  const year = Number(yearPart);
-  const semesterOrderMap = {
-    1: 1,
-    S: 2,
-    2: 3,
-    W: 4,
-  };
-
-  return {
-    year: Number.isNaN(year) ? -1 : year,
-    semesterOrder: semesterOrderMap[semesterPart] ?? 99,
-  };
-}
-
-function sortTermsDesc(a, b) {
-  const parsedA = parseTerm(a);
-  const parsedB = parseTerm(b);
-
-  if (parsedA.year !== parsedB.year) return parsedB.year - parsedA.year;
-  return parsedB.semesterOrder - parsedA.semesterOrder;
-}
+const formerDevelopersBySemester = [
+  {
+    semester: '2025-2',
+    members: [
+      {
+        name: '강명석',
+        image: '/devs/kms.jpg',
+        description: 'init 정상화해줬잖아 기능정의도해줬잖아 그냥 다해줬잖아',
+      },
+      {
+        name: '이한경',
+        image: '/devs/lhk.jpg',
+        description: '한경님의 백엔드 너무 좋아앗',
+      },
+      {
+        name: '박성현',
+        image: '/devs/psh.jpg',
+        description: '아주아주 귀여운 여고생',
+      },
+      {
+        name: '최정원',
+        image: '',
+        description: '',
+      },
+      {
+        name: '이태윤',
+        image: '',
+        description: '',
+      },
+      {
+        name: '윤영우',
+        image: '/devs/yyw.jpg',
+        description: '고능',
+      },
+      {
+        name: '박상혁(Ethan)',
+        image: '/devs/psh.jpg',
+        description: 'SCSC 막스 베르슈타펜',
+      },
+    ],
+  },
+  {
+    semester: '2025-1',
+    members: [
+      {
+        name: '강명석',
+        image: '/devs/kms.jpg',
+        description: 'init 정상화해줬잖아 기능정의도해줬잖아 그냥 다해줬잖아',
+      },
+      {
+        name: '이한경',
+        image: '/devs/lhk.jpg',
+        description: '한경님의 백엔드 너무 좋아앗',
+      },
+      {
+        name: '박성현',
+        image: '/devs/psh.jpg',
+        description: '아주아주 귀여운 여고생',
+      },
+      {
+        name: '황민기',
+        image: '/devs/hmk.jpg',
+        description: '커밋주작은뭐야',
+      },
+      {
+        name: '윤영우',
+        image: '/devs/yyw.jpg',
+        description: '고능',
+      },
+    ],
+  },
+];
 
 function FormerDevelopersSection({ semesterGroups }) {
-  if (semesterGroups.length === 0) return null;
-
   return (
     <section className={developerStyles.formerDevelopersSection}>
       <div className={developerStyles.formerDevelopersHeader}>
@@ -113,10 +120,10 @@ function FormerDevelopersSection({ semesterGroups }) {
             <div className={developerStyles.formerSemesterTitle}>{semesterGroup.semester}</div>
 
             <div className={developerStyles.formerMembersGrid}>
-              {semesterGroup.members.map((member) => (
-                <div
-                  key={`${semesterGroup.semester}-${member.name}`}
-                  className={developerStyles.formerMemberItem}
+              {semesterGroup.members.map((member, index) => (
+                <article
+                  key={`${semesterGroup.semester}-${member.name}-${index}`}
+                  className={developerStyles.formerMemberCard}
                 >
                   <div className={developerStyles.formerMemberImageWrap}>
                     <Image
@@ -127,8 +134,13 @@ function FormerDevelopersSection({ semesterGroups }) {
                     />
                   </div>
 
-                  <div className={developerStyles.formerMemberName}>{member.name}</div>
-                </div>
+                  <div className={developerStyles.formerMemberText}>
+                    <div className={developerStyles.formerMemberName}>{member.name}</div>
+                    <div className={developerStyles.formerMemberDescription}>
+                      {member.description}
+                    </div>
+                  </div>
+                </article>
               ))}
             </div>
           </div>
@@ -141,103 +153,25 @@ function FormerDevelopersSection({ semesterGroups }) {
 export default function ExecutivesClient() {
   const [centerIndex, setCenterIndex] = useState(0);
   const [hovered, setHovered] = useState(false);
-  const [currentTerm, setCurrentTerm] = useState('26-1');
   const autoRef = useRef();
-
-  useEffect(() => {
-    let ignore = false;
-
-    const fetchCurrentTerm = async () => {
-      try {
-        const res = await fetch('/api/scsc/global/status', {
-          cache: 'no-store',
-        });
-
-        if (!res.ok) return;
-
-        const data = await res.json();
-        const formatted = formatTerm(data?.year, data?.semester);
-
-        if (!ignore && formatted) {
-          setCurrentTerm(formatted);
-        }
-      } catch (error) {
-        console.error('현재 학기 정보를 불러오지 못했습니다.', error);
-      }
-    };
-
-    fetchCurrentTerm();
-
-    return () => {
-      ignore = true;
-    };
-  }, []);
-
-  const { currentDevelopers, formerDevelopersBySemester } = useMemo(() => {
-    const current = developers.filter((developer) =>
-      developer.activeTerms.includes(currentTerm),
-    );
-
-    const formerGroupsMap = new Map();
-
-    developers.forEach((developer) => {
-      developer.activeTerms
-        .filter((term) => term !== currentTerm)
-        .forEach((term) => {
-          if (!formerGroupsMap.has(term)) {
-            formerGroupsMap.set(term, []);
-          }
-
-          formerGroupsMap.get(term).push({
-            name: developer.name,
-            image: developer.image,
-            description: developer.description,
-          });
-        });
-    });
-
-    const formerGroups = Array.from(formerGroupsMap.entries())
-      .sort(([termA], [termB]) => sortTermsDesc(termA, termB))
-      .map(([semester, members]) => ({
-        semester,
-        members,
-      }));
-
-    return {
-      currentDevelopers: current,
-      formerDevelopersBySemester: formerGroups,
-    };
-  }, [currentTerm]);
-
-  const total = currentDevelopers.length;
+  const total = executives.length;
 
   const next = useCallback(() => {
-    if (total === 0) return;
     setCenterIndex((prev) => (prev + 1) % total);
   }, [total]);
 
   const prev = useCallback(() => {
-    if (total === 0) return;
     setCenterIndex((prev) => (prev - 1 + total) % total);
   }, [total]);
 
   useEffect(() => {
-    if (centerIndex >= total) {
-      setCenterIndex(0);
-    }
-  }, [centerIndex, total]);
-
-  useEffect(() => {
-    if (total === 0) return undefined;
-
     if (!hovered) {
       autoRef.current = setInterval(() => {
         next();
       }, 4000);
     }
-
     return () => clearInterval(autoRef.current);
-  }, [hovered, next, total]);
+  }, [hovered, next]);
 
   const handlers = useSwipeable({
     onSwipedLeft: next,
@@ -246,8 +180,6 @@ export default function ExecutivesClient() {
   });
 
   const positionClass = (idx) => {
-    if (total === 0) return '';
-
     const offset = (idx - centerIndex + total) % total;
     if (offset === 0) return styles.carouselCardCenter;
     if (offset === 1 || offset === -total + 1) return styles.carouselCardRight1;
@@ -266,10 +198,10 @@ export default function ExecutivesClient() {
         {...handlers}
       >
         <div className={styles.carouselCentered}>
-          {currentDevelopers.map((person, idx) => (
+          {executives.map((person, idx) => (
             <div
               className={`${styles.carouselCard} ${positionClass(idx)}`}
-              key={person.name}
+              key={idx}
               style={{
                 transition: 'transform 0.6s ease, opacity 0.6s ease',
               }}
@@ -286,11 +218,10 @@ export default function ExecutivesClient() {
             </div>
           ))}
         </div>
-
         <div className={styles.carouselDots}>
-          {currentDevelopers.map((person, i) => (
+          {executives.map((_, i) => (
             <div
-              key={person.name}
+              key={i}
               className={`${styles.carouselDot} ${i === centerIndex ? styles.carouselDotActive : ''}`}
               onClick={() => setCenterIndex(i)}
             />
@@ -299,8 +230,8 @@ export default function ExecutivesClient() {
       </div>
 
       <div className={styles.masonry}>
-        {currentDevelopers.map((person) => (
-          <div className={styles.masonryCard} key={person.name}>
+        {executives.map((person, i) => (
+          <div className={styles.masonryCard} key={i}>
             <div className={styles.imageWrapper}>
               <Image
                 src={person.image || '/asset/default-pfp.png'}

--- a/src/app/about/developers/developers.module.css
+++ b/src/app/about/developers/developers.module.css
@@ -10,7 +10,7 @@
   align-items: end;
   justify-content: space-between;
   gap: 16px;
-  margin-bottom: 18px;
+  margin-bottom: 20px;
 }
 
 .formerDevelopersTitle {
@@ -23,11 +23,11 @@
 .formerSemesterList {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 18px;
 }
 
 .formerSemesterBlock {
-  padding: 16px 18px;
+  padding: 18px 20px;
   border: 1px solid var(--header-border-color);
   border-radius: 18px;
   background: var(--executive-card-bg);
@@ -36,38 +36,54 @@
 
 .formerSemesterTitle {
   margin-bottom: 14px;
-  font-size: 0.98rem;
+  font-size: 1rem;
   font-weight: 700;
   color: var(--executive-name-color);
 }
 
 .formerMembersGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
-  gap: 16px 18px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px 16px;
 }
 
-.formerMemberItem {
+.formerMemberCard {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
+  min-width: 0;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: var(--color-primary);
+  border: 1px solid var(--header-border-color);
 }
 
 .formerMemberImageWrap {
   position: relative;
-  width: 64px;
-  height: 64px;
-  border-radius: 999px;
+  width: 52px;
+  height: 52px;
+  flex: 0 0 52px;
   overflow: hidden;
+  border-radius: 999px;
+}
+
+.formerMemberText {
+  min-width: 0;
 }
 
 .formerMemberName {
-  font-size: 0.85rem;
-  font-weight: 600;
-  line-height: 1.3;
-  text-align: center;
+  font-size: 0.98rem;
+  font-weight: 700;
+  line-height: 1.2;
   color: var(--executive-name-color);
+  word-break: keep-all;
+}
+
+.formerMemberDescription {
+  margin-top: 4px;
+  font-size: 0.88rem;
+  line-height: 1.35;
+  color: var(--executive-role-color);
   word-break: keep-all;
 }
 
@@ -83,21 +99,31 @@
   }
 
   .formerSemesterBlock {
-    padding: 14px 16px;
+    padding: 16px;
     border-radius: 16px;
   }
 
   .formerMembersGrid {
-    grid-template-columns: repeat(auto-fill, minmax(82px, 1fr));
-    gap: 14px 16px;
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  .formerMemberCard {
+    padding: 10px;
+    gap: 10px;
   }
 
   .formerMemberImageWrap {
-    width: 58px;
-    height: 58px;
+    width: 46px;
+    height: 46px;
+    flex-basis: 46px;
   }
 
   .formerMemberName {
+    font-size: 0.93rem;
+  }
+
+  .formerMemberDescription {
     font-size: 0.82rem;
   }
 }
@@ -107,7 +133,7 @@
     flex-direction: column;
     align-items: flex-start;
     gap: 6px;
-    margin-bottom: 14px;
+    margin-bottom: 16px;
   }
 
   .formerDevelopersSection {
@@ -115,27 +141,32 @@
     padding-top: 20px;
   }
 
+  .formerSemesterTitle {
+    font-size: 0.95rem;
+    margin-bottom: 12px;
+  }
+
   .formerSemesterBlock {
-    padding: 12px 14px;
+    padding: 14px;
     border-radius: 14px;
   }
 
-  .formerSemesterTitle {
-    margin-bottom: 12px;
-    font-size: 0.93rem;
-  }
-
-  .formerMembersGrid {
-    grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
-    gap: 14px;
+  .formerMemberCard {
+    border-radius: 12px;
   }
 
   .formerMemberImageWrap {
-    width: 52px;
-    height: 52px;
+    width: 42px;
+    height: 42px;
+    flex-basis: 42px;
   }
 
   .formerMemberName {
-    font-size: 0.78rem;
+    font-size: 0.9rem;
+  }
+
+  .formerMemberDescription {
+    font-size: 0.8rem;
+    line-height: 1.3;
   }
 }


### PR DESCRIPTION

<img width="2073" height="1379" alt="image" src="https://github.com/user-attachments/assets/8209b4b3-ade5-44ed-b14f-1142a721e0ce" />
<img width="556" height="1242" alt="image" src="https://github.com/user-attachments/assets/7c408ef1-8d2b-4d2f-9b41-9138e349b87c" />


구현 방식에 대한 설명입니다

1. json에 과거-현재 구별란을 넣지 않고 별도의 변수를 만든 이유
: 과거 개발자를 그대로 두고 value만 수정하는 식으로 쌓이면 현재-과거 개발자가 섞여버림

2. 2025-2가 있는 이유
: 시간 정도는 두는게 좋아보였음

3. 드랍다운처럼 클릭하면 보이게 안하고 그냥 보이게 해서 스크롤이 생기게 한 이유
: 굳이 useState를 쓸 매력이 느껴지지 않음

4. description 둔 이유
: 원래 있던거고 여러 사이트들의 개발자 페이지의 선례를 들어 description 정도는 두는게 좋다고 생각

<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->

### What feature does this PR add?

<!-- Describe the feature or enhancement you implemented -->

---

### Are there any caveats or things to watch out for?

<!-- If none, write "None" -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Former Developers" section that groups past contributors by semester
  * Current-term filtering continues to display active developers for the ongoing period
  * Improved image handling with automatic fallback for missing profile pictures

* **Style**
  * Enhanced responsive layout, spacing and typography for mobile and tablet viewing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->