### PR TITLE
add website registration to sig/create

### DIFF
--- a/src/app/sig/create/CreateSigClient.jsx
+++ b/src/app/sig/create/CreateSigClient.jsx
@@ -105,6 +105,7 @@ export default function CreateSigClient({ scscGlobalStatus }) {
     try {
       const res = await fetch('/api/sig/create', {
         method: 'POST',
+        credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           title: data.title,

--- a/src/app/sig/create/CreateSigClient.jsx
+++ b/src/app/sig/create/CreateSigClient.jsx
@@ -4,6 +4,7 @@ import SigForm from '@/components/board/SigForm';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState, useRef } from 'react';
 import { useForm } from 'react-hook-form';
+import { directFetch } from '@/util/directFetch';
 import { pushLoginWithRedirect } from '@/util/loginRedirect';
 
 const sanitizeWebsites = (websites = []) =>
@@ -103,7 +104,7 @@ export default function CreateSigClient({ scscGlobalStatus }) {
     setSubmitting(true);
 
     try {
-      const res = await fetch('/api/sig/create', {
+      const res = await directFetch('/api/sig/create', {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },

--- a/src/app/sig/create/CreateSigClient.jsx
+++ b/src/app/sig/create/CreateSigClient.jsx
@@ -4,8 +4,15 @@ import SigForm from '@/components/board/SigForm';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState, useRef } from 'react';
 import { useForm } from 'react-hook-form';
-import { directFetch } from '@/util/directFetch';
 import { pushLoginWithRedirect } from '@/util/loginRedirect';
+
+const sanitizeWebsites = (websites = []) =>
+  (Array.isArray(websites) ? websites : [])
+    .map((site, index) => {
+      const url = site?.url?.trim() ?? '';
+      return { label: url || `링크 ${index + 1}`, url, sort_order: index };
+    })
+    .filter((site) => site.url);
 
 export default function CreateSigClient({ scscGlobalStatus }) {
   const router = useRouter();
@@ -28,6 +35,7 @@ export default function CreateSigClient({ scscGlobalStatus }) {
       description: '',
       editor: '',
       is_rolling_admission: scscGlobalStatus === 'active',
+      websites: [{ url: '' }],
     },
   });
 
@@ -95,7 +103,7 @@ export default function CreateSigClient({ scscGlobalStatus }) {
     setSubmitting(true);
 
     try {
-      const res = await directFetch('/api/sig/create', {
+      const res = await fetch('/api/sig/create', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -103,6 +111,7 @@ export default function CreateSigClient({ scscGlobalStatus }) {
           description: data.description,
           content: data.editor,
           is_rolling_admission: data.is_rolling_admission,
+          websites: sanitizeWebsites(data.websites),
         }),
       });
 

--- a/src/app/sig/create/CreateSigClient.jsx
+++ b/src/app/sig/create/CreateSigClient.jsx
@@ -106,7 +106,6 @@ export default function CreateSigClient({ scscGlobalStatus }) {
     try {
       const res = await directFetch('/api/sig/create', {
         method: 'POST',
-        credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           title: data.title,

--- a/src/components/board/SigForm.jsx
+++ b/src/components/board/SigForm.jsx
@@ -5,6 +5,7 @@ import * as Button from '@/components/Button.jsx';
 import * as Input from '@/components/Input.jsx';
 import ToggleSwitch from '@/components/ToggleSwitch.jsx';
 import { Controller, useFieldArray } from 'react-hook-form';
+import styles from './board.module.css';
 
 export default function SigForm({
   register,
@@ -52,7 +53,7 @@ export default function SigForm({
         />
       </div>
 
-      <div className="space-y-2" style={{ marginTop: '1.5rem' }}>
+      <div className={styles.websiteSection}>
         <span className="font-semibold">웹사이트</span>
 
         <div className="space-y-3">

--- a/src/components/board/SigForm.jsx
+++ b/src/components/board/SigForm.jsx
@@ -1,8 +1,10 @@
+import { useCallback } from 'react';
 import Editor from '@/components/board/EditorWrapper.jsx';
 import InputField from './InputField';
 import * as Button from '@/components/Button.jsx';
+import * as Input from '@/components/Input.jsx';
 import ToggleSwitch from '@/components/ToggleSwitch.jsx';
-import { Controller } from 'react-hook-form';
+import { Controller, useFieldArray } from 'react-hook-form';
 
 export default function SigForm({
   register,
@@ -12,6 +14,12 @@ export default function SigForm({
   editorKey,
   isCreate,
 }) {
+  const { fields, append, remove } = useFieldArray({ control, name: 'websites' });
+
+  const handleAddWebsite = useCallback(() => {
+    append({ url: '' });
+  }, [append]);
+
   return (
     <form
       className="space-y-4"
@@ -42,6 +50,47 @@ export default function SigForm({
             />
           )}
         />
+      </div>
+
+      <div className="space-y-2" style={{ marginTop: '1.5rem' }}>
+        <span className="font-semibold">웹사이트</span>
+
+        <div className="space-y-3">
+          {fields.map((field, index) => {
+            const fieldId = `website-url-${index}`;
+            return (
+              <div key={field.id} className="PigUrlRow">
+                <Input.Root className="PigUrlField">
+                  <Input.Label htmlFor={fieldId}>URL</Input.Label>
+                  <Input.Input
+                    id={fieldId}
+                    className="PigUrlInput"
+                    type="text"
+                    inputMode="url"
+                    placeholder="https://example.com"
+                    {...register(`websites.${index}.url`)}
+                  />
+                </Input.Root>
+                {fields.length > 1 && (
+                  <button
+                    type="button"
+                    className="PigUrlRemove text-sm text-red-500 hover:underline"
+                    onClick={() => remove(index)}
+                  >
+                    삭제
+                  </button>
+                )}
+              </div>
+            );
+          })}
+          <button
+            type="button"
+            className="text-sm text-blue-500 hover:underline"
+            onClick={handleAddWebsite}
+          >
+            웹사이트 추가
+          </button>
+        </div>
       </div>
 
       <div className="form-toggle-row">

--- a/src/components/board/board.module.css
+++ b/src/components/board/board.module.css
@@ -346,3 +346,10 @@
   width: 1rem;
   height: 1rem;
 }
+
+.websiteSection {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}


### PR DESCRIPTION
### 이 PR이 고친 이슈

fixed #510

---

### 이 PR은 어떤 기능을 추가하나요?

✨ `pig/create`에 이미 구현된 웹사이트 등록 기능을 `sig/create`에도 동일하게 추가했습니다.

- `SigForm.jsx`에 웹사이트 URL 입력 필드, 추가/삭제 버튼 추가
- ♻️ `CreateSigClient.jsx`에 `sanitizeWebsites` 헬퍼 함수 추가 및 폼 제출 시 `websites` 필드 포함

---

### 주의사항이 있나요?

없음

<img width="793" height="736" alt="Screenshot 2026-05-04 at 1 09 50 PM" src="https://github.com/user-attachments/assets/0acc3df2-7233-41bc-a1e9-7ab6a40a0d38" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can add/remove multiple website entries when creating a SIG; new default empty website row is shown.
  * Submitted SIGs now include cleaned website entries (trimmed URLs, generated fallback labels, and preserved order) in the payload.
* **Style**
  * Improved form layout spacing for the website section and standardized checkbox sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->