### PR TITLE
✨SIG 관리자 페이지 SIG Website 관리 기능 구현

### DIFF
--- a/src/app/executive/sig/SigList.jsx
+++ b/src/app/executive/sig/SigList.jsx
@@ -61,7 +61,18 @@ function SigFilterRow({ filter, updateFilterCriteria }) {
   );
 }
 
-const RenderSigRow = ({ sig }) => {
+const RenderSigRow = ({ sig, onUpdateSig }) => {
+  const [websites, setWebsites] = useState(sig.websites || []);
+  const handleUrlChange = (idx, newUrl) => {
+    const nextWebsites = [...websites];
+    nextWebsites[idx] = { ...nextWebsites[idx], url: newUrl };
+    setWebsites(nextWebsites);
+  };
+  const handleSave = () => {
+    if (onUpdateSig) {
+      onUpdateSig(sig.id, { websites });
+    }
+  };
   return (
     <tr className={styles['adm-tr']}>
       <td className={styles['adm-td']}>{sig.title ?? ''}</td>
@@ -69,6 +80,23 @@ const RenderSigRow = ({ sig }) => {
       <td className={styles['adm-td']}>{sig.year ?? ''}</td>
       <td className={styles['adm-td']}>{SEMESTER_MAP[Number(sig.semester)] ?? ''}학기</td>
       <td className={styles['adm-td']}>{sig.ownerName ?? ''}</td>
+      <td className={styles['adm-td']}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+          {websites.map((web, idx) => (
+            <div key={idx} style={{ display: 'flex', gap: '2px', alignItems: 'center' }}>
+              <input
+                type="text"
+                className={styles['adm-input']}
+                value={web.url}
+                placeholder="URL (https://...)"
+                style={{ width: '100%', padding: '4px' }}
+                onChange={(e) => handleUrlChange(idx, e.target.value)}
+                onBlur={handleSave}
+              />
+            </div>
+          ))}
+        </div>
+      </td>
       <td className={styles['adm-td']}>
         <a href={`/executive/sig/${sig.id}`}>상세보기</a>
       </td>
@@ -115,6 +143,7 @@ export default function SigList({ sigs }) {
             <th className={styles['adm-th']}>연도</th>
             <th className={styles['adm-th']}>학기</th>
             <th className={styles['adm-th']}>SIG장</th>
+            <th className={styles['adm-th']}>웹사이트</th>
             <th className={styles['adm-th']}>상세보기</th>
           </tr>
           <SigFilterRow


### PR DESCRIPTION
<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->

### What feature does this PR add?

<!-- Describe the feature or enhancement you implemented -->

---
sig 관리자 페이지에 sig website 관리 기능을 추가하였습니다.
<img width="1732" height="622" alt="sig-management-page" src="https://github.com/user-attachments/assets/1cfef764-1864-4348-8038-ae9ee2139dfa" />


### Are there any caveats or things to watch out for?

<!-- If none, write "None" -->
None
fix #446 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new website column to the SIG list
  * Users can now edit website URLs directly in the table with inline text inputs
  * Updated website entries are automatically saved when the input field loses focus

<!-- end of auto-generated comment: release notes by coderabbit.ai -->