### PR TITLE
♻️  theme.css 일관성 개선

### DIFF
--- a/src/app/Footer.module.css
+++ b/src/app/Footer.module.css
@@ -38,7 +38,7 @@
 }
 
 .logo {
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   padding: 0.75rem;
   border-radius: 50%;
   display: flex;

--- a/src/app/Not-found.module.css
+++ b/src/app/Not-found.module.css
@@ -24,8 +24,8 @@
   width: 100%;
   max-width: 48rem;
   border: 1px solid var(--header-border-color);
-  background: var(--executive-card-bg);
-  box-shadow: 0 24px 60px var(--executive-card-shadow);
+  background: var(--color-card-bg);
+  box-shadow: 0 24px 60px var(--color-card-shadow);
   border-radius: 1.25rem;
   padding: 2.25rem 2rem 2rem;
   overflow: hidden;

--- a/src/app/about/about.module.css
+++ b/src/app/about/about.module.css
@@ -1,10 +1,10 @@
 /* Regulation Specific */
 .regulationCard {
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   padding: 2rem;
   border-radius: 1rem;
   border: 2px solid var(--color-button-border);
-  box-shadow: 0 4px 8px var(--executive-card-shadow);
+  box-shadow: 0 4px 8px var(--color-card-shadow);
   color: var(--color-text-body);
   font-size: 1.1rem;
   line-height: 1.6;
@@ -135,18 +135,18 @@
 }
 /* Shared Card Styles */
 .card {
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   border: 1px solid var(--header-border-color);
   border-radius: 1rem;
   padding: 1.5rem;
-  box-shadow: 0 3px 12px var(--executive-card-shadow);
+  box-shadow: 0 3px 12px var(--color-card-shadow);
   color: var(--foreground-color);
   overflow: hidden;
 }
 
 .cardHover:hover {
   transform: translateY(-4px);
-  box-shadow: 0 6px 16px var(--executive-card-shadow);
+  box-shadow: 0 6px 16px var(--color-card-shadow);
   transition:
     transform 0.2s ease,
     box-shadow 0.2s ease;
@@ -227,7 +227,7 @@
 
 .carouselCard {
   width: 200px;
-  background: var(--executive-card-bg);
+  background: var(--color-card-bg);
   color: var(--executive-name-color);
   border-radius: 1rem;
   text-align: center;
@@ -243,7 +243,7 @@
     opacity 0.6s ease;
   z-index: 1;
   pointer-events: none;
-  box-shadow: 0 3px 12px var(--executive-card-shadow);
+  box-shadow: 0 3px 12px var(--color-card-shadow);
 }
 
 .carouselCardCenter {
@@ -336,11 +336,11 @@
   transform: none;
   opacity: 1;
   pointer-events: auto;
-  background: var(--executive-card-bg);
+  background: var(--color-card-bg);
   border-radius: 1rem;
   text-align: center;
   padding: 1rem;
-  box-shadow: 0 3px 12px var(--executive-card-shadow);
+  box-shadow: 0 3px 12px var(--color-card-shadow);
 }
 
 .overlay {
@@ -423,12 +423,12 @@
 }
 
 .clubroomContainer {
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   border: 1px solid var(--header-border-color);
   border-radius: 1rem;
   padding: 3rem 2rem;
   margin-top: 3rem;
-  box-shadow: 0 3px 12px var(--executive-card-shadow);
+  box-shadow: 0 3px 12px var(--color-card-shadow);
   color: var(--foreground-color);
 }
 
@@ -448,7 +448,7 @@
   border-radius: 0.75rem;
   text-decoration: none;
   color: var(--foreground-color);
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   transition:
     background-color 0.2s ease,
     transform 0.2s ease;
@@ -500,11 +500,11 @@
 }
 
 .faqItem {
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   border: 1px solid var(--header-border-color);
   border-radius: 0.75rem;
   padding: 1rem 1.25rem;
-  box-shadow: 0 3px 12px var(--executive-card-shadow);
+  box-shadow: 0 3px 12px var(--color-card-shadow);
 }
 
 .faqQuestion {
@@ -565,7 +565,7 @@
   padding: 1.5rem;
   border: 2px solid var(--color-button-border);
   border-radius: 1rem;
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.04);
   transition: box-shadow 0.3s ease;
 }
@@ -599,10 +599,10 @@
 }
 
 .myPageCard {
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   padding: 1rem;
   border-radius: 1rem;
-  box-shadow: 0 4px 20px var(--executive-card-shadow);
+  box-shadow: 0 4px 20px var(--color-card-shadow);
   min-width: 300px;
   width: auto;
   min-height: 40vh;
@@ -702,8 +702,8 @@
   padding: 1.35rem 1.75rem;
   border-radius: 1.25rem;
   border: 1px solid var(--color-button-border);
-  background-color: var(--executive-card-bg);
-  box-shadow: 0 4px 12px var(--executive-card-shadow);
+  background-color: var(--color-card-bg);
+  box-shadow: 0 4px 12px var(--color-card-shadow);
 }
 
 .welcomeSubtitle {
@@ -724,8 +724,8 @@
   padding: 1.6rem 1.9rem;
   border-radius: 1.25rem;
   border: 1px solid var(--color-button-border);
-  background-color: var(--executive-card-bg);
-  box-shadow: 0 6px 14px var(--executive-card-shadow);
+  background-color: var(--color-card-bg);
+  box-shadow: 0 6px 14px var(--color-card-shadow);
 }
 
 .stepHeader {

--- a/src/app/article/[id]/page.css
+++ b/src/app/article/[id]/page.css
@@ -4,8 +4,8 @@
   margin: 1.5rem auto;
   padding: 1.5rem;
   border-radius: 1rem;
-  box-shadow: 0 3px 12px var(--executive-card-shadow);
-  background-color: var(--executive-card-bg);
+  box-shadow: 0 3px 12px var(--color-card-shadow);
+  background-color: var(--color-card-bg);
 }
 
 html,
@@ -38,7 +38,7 @@ body {
 
 .SigDivider {
   border: none;
-  border-top: 1px solid var(--executive-card-shadow);
+  border-top: 1px solid var(--color-card-shadow);
   margin: 2rem 0;
 }
 
@@ -79,7 +79,7 @@ body {
 }
 
 .mdx-pre {
-  background: var(--executive-card-bg);
+  background: var(--color-card-bg);
   padding: 1rem;
   overflow-x: auto;
   border-radius: 0.5rem;
@@ -131,7 +131,7 @@ body {
     transform 120ms ease,
     background-color 120ms ease,
     box-shadow 120ms ease;
-  box-shadow: 0 2px 6px var(--executive-card-shadow);
+  box-shadow: 0 2px 6px var(--color-card-shadow);
   min-width: 0;
 }
 
@@ -173,7 +173,7 @@ body {
 .SigContent + div {
   margin-top: 1.25rem;
   padding-top: 1rem;
-  border-top: 1px solid var(--executive-card-shadow);
+  border-top: 1px solid var(--color-card-shadow);
 }
 
 .SigContent + div > button {
@@ -191,7 +191,7 @@ body {
     transform 120ms ease,
     background-color 120ms ease,
     box-shadow 120ms ease;
-  box-shadow: 0 2px 6px var(--executive-card-shadow);
+  box-shadow: 0 2px 6px var(--color-card-shadow);
   margin-bottom: 0.75rem;
 }
 
@@ -206,12 +206,12 @@ body {
 }
 
 .SigContent + div > div {
-  background: var(--executive-card-bg);
+  background: var(--color-card-bg);
   border: 1px solid var(--color-button-border);
   border-radius: 0.75rem;
   padding: 0.8rem 1rem;
   margin-bottom: 0.75rem;
-  box-shadow: 0 2px 6px var(--executive-card-shadow);
+  box-shadow: 0 2px 6px var(--color-card-shadow);
   color: var(--color-text-subtle);
   line-height: 1.6;
 }
@@ -227,10 +227,10 @@ body {
   resize: vertical;
   border-radius: 0.6rem;
   padding: 0.6rem 0.75rem;
-  background: var(--executive-card-bg);
+  background: var(--color-card-bg);
   color: var(--color-text);
   border: 1px solid var(--color-button-border);
-  box-shadow: inset 0 0 0 1px var(--executive-card-shadow);
+  box-shadow: inset 0 0 0 1px var(--color-card-shadow);
   margin: 0.5rem 0;
 }
 
@@ -254,7 +254,7 @@ body {
     transform 120ms ease,
     background-color 120ms ease,
     box-shadow 120ms ease;
-  box-shadow: 0 2px 6px var(--executive-card-shadow);
+  box-shadow: 0 2px 6px var(--color-card-shadow);
   margin-right: 0.4rem;
 }
 

--- a/src/app/board/[id]/create/page.css
+++ b/src/app/board/[id]/create/page.css
@@ -161,7 +161,7 @@ form input[type='text']:focus {
 }
 
 .SigCreateBtn:hover:not(:disabled) {
-  background-color: var(--color-button-bg);
+  background-color: var(--color-button-hover-bg);
   transform: translateY(-2px);
 }
 
@@ -261,7 +261,7 @@ input[type='text']:focus {
 }
 
 .SigCreateBtn:hover:not(:disabled) {
-  background-color: var(--color-button-bg);
+  background-color: var(--color-button-hover-bg);
   transform: translateY(-2px);
 }
 

--- a/src/app/board/[id]/create/page.css
+++ b/src/app/board/[id]/create/page.css
@@ -37,9 +37,9 @@ body {
   margin-top: 1rem;
 }
 .CreateSigCard {
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   padding: 2rem;
-  box-shadow: 0 3px 12px var(--executive-card-shadow);
+  box-shadow: 0 3px 12px var(--color-card-shadow);
   border-radius: 1rem;
 }
 .CreateSigContainer {
@@ -92,7 +92,7 @@ input::placeholder {
 }
 
 .mdxeditor {
-  background-color: rgb(202, 202, 202);
+  background-color: var(--color-editor-bg);
   border-radius: 0.5rem;
   min-height: 20rem;
   margin-top: 1rem;
@@ -107,8 +107,8 @@ label {
 /* 글 작성 페이지: 다크모드 및 스타일 개선 */
 /* ============================= */
 .dark .CreateSigCard {
-  background-color: var(--executive-card-bg);
-  box-shadow: 0 3px 12px var(--executive-card-shadow);
+  background-color: var(--color-card-bg);
+  box-shadow: 0 3px 12px var(--color-card-shadow);
   color: var(--color-text-body);
 }
 
@@ -161,7 +161,7 @@ form input[type='text']:focus {
 }
 
 .SigCreateBtn:hover:not(:disabled) {
-  background-color: #2da6bd;
+  background-color: var(--color-button-bg);
   transform: translateY(-2px);
 }
 
@@ -182,9 +182,9 @@ form input[type='text']:focus {
 }
 
 .CreateSigCard {
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   padding: 2.5rem;
-  box-shadow: 0 6px 20px var(--executive-card-shadow);
+  box-shadow: 0 6px 20px var(--color-card-shadow);
   border-radius: 1.25rem;
 }
 
@@ -261,7 +261,7 @@ input[type='text']:focus {
 }
 
 .SigCreateBtn:hover:not(:disabled) {
-  background-color: #2da6bd;
+  background-color: var(--color-button-bg);
   transform: translateY(-2px);
 }
 

--- a/src/app/board/[id]/page.css
+++ b/src/app/board/[id]/page.css
@@ -23,7 +23,7 @@
 .sigCard {
   border: 1px solid var(--color-border);
   border-radius: 0.75rem;
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   padding: 1rem 1.25rem;
   display: flex;
   flex-direction: column;
@@ -32,7 +32,7 @@
 }
 
 .sigCard:hover {
-  box-shadow: 0 2px 6px var(--executive-card-shadow);
+  box-shadow: 0 2px 6px var(--color-card-shadow);
 }
 
 .sigTopbar {
@@ -136,11 +136,11 @@
   flex-direction: column;
   gap: 0.4rem;
   transition: box-shadow 0.2s ease;
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
 }
 
 .sigCard:hover {
-  box-shadow: 0 2px 6px var(--executive-card-shadow);
+  box-shadow: 0 2px 6px var(--color-card-shadow);
 }
 
 .sigTopbar {

--- a/src/app/pig/[id]/page.css
+++ b/src/app/pig/[id]/page.css
@@ -5,8 +5,8 @@
   margin: 1.5rem auto;
   padding: 1.5rem;
   border-radius: 1rem;
-  box-shadow: 0 3px 12px var(--executive-card-shadow);
-  background-color: var(--executive-card-bg);
+  box-shadow: 0 3px 12px var(--color-card-shadow);
+  background-color: var(--color-card-bg);
   user-select: text;
   -webkit-user-select: text;
 }
@@ -50,7 +50,7 @@ body {
 /* 구분선 */
 .PigDivider {
   border: none;
-  border-top: 1px solid var(--executive-card-shadow);
+  border-top: 1px solid var(--color-card-shadow);
   margin: 2rem 0;
 }
 
@@ -93,7 +93,7 @@ body {
 }
 
 .mdx-pre {
-  background: var(--executive-card-bg);
+  background: var(--color-card-bg);
   padding: 1rem;
   overflow-x: auto;
   border-radius: 0.5rem;
@@ -121,7 +121,7 @@ body {
   padding: 0.6rem 1rem;
   border-radius: 0.625rem;
   border: 1px solid var(--color-text-subtle);
-  background: var(--executive-card-bg);
+  background: var(--color-card-bg);
   color: var(--color-text);
   font-weight: 600;
   line-height: 1;
@@ -299,7 +299,7 @@ body {
   padding: 0.55rem 0.7rem;
   border-radius: 0.9rem;
   color: var(--color-button-bg);
-  background: var(--executive-card-bg);
+  background: var(--color-card-bg);
   border: 1px solid var(--color-button-border);
   font-weight: 450;
   font-size: 0.85rem;
@@ -307,7 +307,7 @@ body {
     transform 120ms ease,
     background-color 120ms ease,
     box-shadow 120ms ease;
-  box-shadow: 0 2px 6px var(--executive-card-shadow);
+  box-shadow: 0 2px 6px var(--color-card-shadow);
   min-width: 0;
 }
 
@@ -330,7 +330,7 @@ body {
   border-color: var(--color-primary);
   box-shadow:
     inset 0 0 0 1px var(--color-primary),
-    0 2px 6px var(--executive-card-shadow);
+    0 2px 6px var(--color-card-shadow);
 }
 
 .PigButton.is-leave {
@@ -358,7 +358,7 @@ body {
   align-items: center;
   justify-content: center;
   color: var(--color-button-bg);
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   padding: 0.55rem 0.7rem;
   border-radius: 0.9rem;
   border: 1px solid var(--color-button-border);
@@ -380,7 +380,7 @@ body {
   position: absolute;
   top: 110%;
   left: 0;
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   border: 1px solid var(--color-text-subtle);
   border-radius: 0.625rem;
   overflow: hidden;
@@ -487,8 +487,8 @@ body {
   margin-top: 2.25rem;
   padding: 1.25rem 1rem;
   border-radius: 0.75rem;
-  border: 1px solid var(--executive-card-shadow);
-  background: color-mix(in srgb, var(--color-bg) 85%, var(--executive-card-bg) 15%);
+  border: 1px solid var(--color-card-shadow);
+  background: color-mix(in srgb, var(--color-bg) 85%, var(--color-card-bg) 15%);
 }
 
 .PigMembersHeader {
@@ -531,10 +531,10 @@ body {
 .PigMemberChip {
   padding: 0.45rem 0.75rem;
   border-radius: 9999px;
-  background: var(--executive-card-bg);
+  background: var(--color-card-bg);
   border: 1px solid var(--color-button-border);
   color: var(--color-text-body);
-  box-shadow: 0 1px 3px var(--executive-card-shadow);
+  box-shadow: 0 1px 3px var(--color-card-shadow);
 }
 
 .PigMemberOwner {
@@ -542,16 +542,16 @@ body {
   border-radius: 9999px;
   background: var(--color-text-body);
   border: 1px solid var(--color-button-border);
-  color: var(--executive-card-bg);
+  color: var(--color-card-bg);
   font-weight: bold;
-  box-shadow: 0 1px 3px var(--executive-card-shadow);
+  box-shadow: 0 1px 3px var(--color-card-shadow);
 }
 
 .PigMembersEmpty {
   padding: 0.9rem 0.75rem;
   border-radius: 0.5rem;
   border: 1px dashed var(--color-button-border);
-  background: var(--executive-card-bg);
+  background: var(--color-card-bg);
   color: var(--color-text-subtle);
 }
 

--- a/src/app/pig/create/page.css
+++ b/src/app/pig/create/page.css
@@ -37,9 +37,9 @@ body {
   margin-top: 1rem;
 }
 .CreatePigCard {
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   padding: 2rem;
-  box-shadow: 0 3px 12px var(--executive-card-shadow);
+  box-shadow: 0 3px 12px var(--color-card-shadow);
   border-radius: 1rem;
 }
 .CreatePigContainer {
@@ -93,7 +93,7 @@ input::placeholder {
 }
 
 .mdxeditor {
-  background-color: rgb(202, 202, 202);
+  background-color: var(--color-editor-bg);
   border-radius: 0.5rem;
   min-height: 10rem;
 }

--- a/src/app/pig/edit/[id]/page.css
+++ b/src/app/pig/edit/[id]/page.css
@@ -95,9 +95,9 @@ body {
   margin-top: 1rem;
 }
 .CreatePigCard {
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   padding: 2rem;
-  box-shadow: 0 3px 12px var(--executive-card-shadow);
+  box-shadow: 0 3px 12px var(--color-card-shadow);
   border-radius: 1rem;
 }
 .CreatePigContainer {
@@ -151,7 +151,7 @@ input::placeholder {
 }
 
 .mdxeditor {
-  background-color: rgb(202, 202, 202);
+  background-color: var(--color-editor-bg);
   border-radius: 0.5rem;
   min-height: 10rem;
 }

--- a/src/app/pig/page.css
+++ b/src/app/pig/page.css
@@ -32,11 +32,11 @@
   flex-direction: column;
   gap: 0.4rem;
   transition: box-shadow 0.2s ease;
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
 }
 
 .pigCard:hover {
-  box-shadow: 0 2px 6px var(--executive-card-shadow);
+  box-shadow: 0 2px 6px var(--color-card-shadow);
 }
 
 .pigCard.isMine {

--- a/src/app/sig/[id]/page.css
+++ b/src/app/sig/[id]/page.css
@@ -5,8 +5,8 @@
   margin: 1.5rem auto;
   padding: 1.5rem;
   border-radius: 1rem;
-  box-shadow: 0 3px 12px var(--executive-card-shadow);
-  background-color: var(--executive-card-bg);
+  box-shadow: 0 3px 12px var(--color-card-shadow);
+  background-color: var(--color-card-bg);
   user-select: text;
   -webkit-user-select: text;
   position: relative;
@@ -51,7 +51,7 @@ body {
 /* 구분선 */
 .SigDivider {
   border: none;
-  border-top: 1px solid var(--executive-card-shadow);
+  border-top: 1px solid var(--color-card-shadow);
   margin: 2rem 0;
 }
 
@@ -94,7 +94,7 @@ body {
 }
 
 .mdx-pre {
-  background: var(--executive-card-bg);
+  background: var(--color-card-bg);
   padding: 1rem;
   overflow-x: auto;
   border-radius: 0.5rem;
@@ -122,7 +122,7 @@ body {
   padding: 0.6rem 1rem;
   border-radius: 0.625rem;
   border: 1px solid var(--color-text-subtle);
-  background: var(--executive-card-bg);
+  background: var(--color-card-bg);
   color: var(--color-text);
   font-weight: 600;
   line-height: 1;
@@ -300,7 +300,7 @@ body {
   padding: 0.55rem 0.7rem;
   border-radius: 0.9rem;
   color: var(--color-button-bg);
-  background: var(--executive-card-bg);
+  background: var(--color-card-bg);
   border: 1px solid var(--color-button-border);
   font-weight: 450;
   font-size: 0.85rem;
@@ -308,7 +308,7 @@ body {
     transform 120ms ease,
     background-color 120ms ease,
     box-shadow 120ms ease;
-  box-shadow: 0 2px 6px var(--executive-card-shadow);
+  box-shadow: 0 2px 6px var(--color-card-shadow);
   min-width: 0;
 }
 
@@ -352,7 +352,7 @@ body {
   align-items: center;
   justify-content: center;
   color: var(--color-button-bg);
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   padding: 0.55rem 0.7rem;
   border-radius: 0.9rem;
   border: 1px solid var(--color-button-border);
@@ -374,7 +374,7 @@ body {
   position: absolute;
   top: 110%;
   left: 0;
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   border: 1px solid var(--color-text-subtle);
   border-radius: 0.625rem;
   overflow: hidden;
@@ -481,8 +481,8 @@ body {
   margin-top: 2.25rem;
   padding: 1.25rem 1rem;
   border-radius: 0.75rem;
-  border: 1px solid var(--executive-card-shadow);
-  background: color-mix(in srgb, var(--color-bg) 85%, var(--executive-card-bg) 15%);
+  border: 1px solid var(--color-card-shadow);
+  background: color-mix(in srgb, var(--color-bg) 85%, var(--color-card-bg) 15%);
 }
 
 .SigMembersHeader {
@@ -525,10 +525,10 @@ body {
 .SigMemberChip {
   padding: 0.45rem 0.75rem;
   border-radius: 9999px;
-  background: var(--executive-card-bg);
+  background: var(--color-card-bg);
   border: 1px solid var(--color-button-border);
   color: var(--color-text-body);
-  box-shadow: 0 1px 3px var(--executive-card-shadow);
+  box-shadow: 0 1px 3px var(--color-card-shadow);
 }
 
 .SigMemberOwner {
@@ -536,16 +536,16 @@ body {
   border-radius: 9999px;
   background: var(--color-text-body);
   border: 1px solid var(--color-button-border);
-  color: var(--executive-card-bg);
+  color: var(--color-card-bg);
   font-weight: bold;
-  box-shadow: 0 1px 3px var(--executive-card-shadow);
+  box-shadow: 0 1px 3px var(--color-card-shadow);
 }
 
 .SigMembersEmpty {
   padding: 0.9rem 0.75rem;
   border-radius: 0.5rem;
   border: 1px dashed var(--color-button-border);
-  background: var(--executive-card-bg);
+  background: var(--color-card-bg);
   color: var(--color-text-subtle);
 }
 

--- a/src/app/sig/create/page.css
+++ b/src/app/sig/create/page.css
@@ -37,9 +37,9 @@ body {
   margin-top: 1rem;
 }
 .CreateSigCard {
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   padding: 2rem;
-  box-shadow: 0 3px 12px var(--executive-card-shadow);
+  box-shadow: 0 3px 12px var(--color-card-shadow);
   border-radius: 1rem;
 }
 .CreateSigContainer {
@@ -93,7 +93,7 @@ input::placeholder {
 }
 
 .mdxeditor {
-  background-color: rgb(202, 202, 202);
+  background-color: var(--color-editor-bg);
   border-radius: 0.5rem;
   min-height: 10rem;
 }

--- a/src/app/sig/edit/[id]/page.css
+++ b/src/app/sig/edit/[id]/page.css
@@ -95,9 +95,9 @@ body {
   margin-top: 1rem;
 }
 .CreateSigCard {
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   padding: 2rem;
-  box-shadow: 0 3px 12px var(--executive-card-shadow);
+  box-shadow: 0 3px 12px var(--color-card-shadow);
   border-radius: 1rem;
 }
 .CreateSigContainer {
@@ -151,7 +151,7 @@ input::placeholder {
 }
 
 .mdxeditor {
-  background-color: rgb(202, 202, 202);
+  background-color: var(--color-editor-bg);
   border-radius: 0.5rem;
   min-height: 10rem;
 }

--- a/src/app/sig/sig.module.css
+++ b/src/app/sig/sig.module.css
@@ -30,11 +30,11 @@
     box-shadow 0.2s ease,
     border-color 0.2s ease,
     transform 0.2s ease;
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
 }
 
 .sigCard:hover {
-  box-shadow: 0 2px 6px var(--executive-card-shadow);
+  box-shadow: 0 2px 6px var(--color-card-shadow);
   border-color: var(--color-text-body);
 }
 
@@ -133,7 +133,7 @@
   padding: 0.95rem 1rem;
   border: 1px solid var(--color-text-subtle);
   border-radius: 0.75rem;
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
 }
 
 .SigFilterHeader {

--- a/src/app/us/(auth)/auth.module.css
+++ b/src/app/us/(auth)/auth.module.css
@@ -254,8 +254,8 @@
 }
 
 :global(.dark) .GoogleSignupCard {
-  background-color: var(--executive-card-bg);
-  box-shadow: 0 4px 20px var(--executive-card-shadow);
+  background-color: var(--color-card-bg);
+  box-shadow: 0 4px 20px var(--color-card-shadow);
 }
 
 :global(.dark) .GoogleSignupCard h2 {

--- a/src/app/us/contact/page.css
+++ b/src/app/us/contact/page.css
@@ -62,7 +62,7 @@ body {
   padding: 2.5rem 2rem;
   border: 2px solid var(--color-button-border);
   border-radius: 1rem;
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.04);
   transition: box-shadow 0.3s ease;
 }

--- a/src/app/us/edit-user-info/page.module.css
+++ b/src/app/us/edit-user-info/page.module.css
@@ -13,10 +13,10 @@
 }
 
 .editUserInfoContainer {
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   padding: 1rem;
   border-radius: 1rem;
-  box-shadow: 0 4px 20px var(--executive-card-shadow);
+  box-shadow: 0 4px 20px var(--color-card-shadow);
   width: 30vw;
   min-width: 300px;
   min-height: 40vh;

--- a/src/app/us/fund-apply/create/page.css
+++ b/src/app/us/fund-apply/create/page.css
@@ -24,9 +24,9 @@ body {
 }
 
 .CreateSigCard {
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   padding: 2rem;
-  box-shadow: 0 3px 12px var(--executive-card-shadow);
+  box-shadow: 0 3px 12px var(--color-card-shadow);
   border-radius: 1rem;
 }
 .Step {
@@ -74,7 +74,7 @@ body {
   box-shadow: 0 0 0 2px rgba(75, 176, 201, 0.28);
 }
 select.C_Input option {
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   color: var(--color-text-body);
 }
 .is-disabled,

--- a/src/components/CopyButton.module.css
+++ b/src/components/CopyButton.module.css
@@ -5,12 +5,12 @@
   padding: 0.4rem 0.9rem;
   border-radius: 999px;
   border: 1px solid var(--color-button-border);
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   color: var(--color-button-bg);
   font-size: 0.8rem;
   font-weight: 600;
   cursor: pointer;
-  box-shadow: 0 2px 8px var(--executive-card-shadow);
+  box-shadow: 0 2px 8px var(--color-card-shadow);
   transition:
     box-shadow 0.16s ease,
     transform 0.04s ease,
@@ -19,13 +19,13 @@
 
 .invite-link-copy:hover {
   opacity: 0.95;
-  box-shadow: 0 4px 12px var(--executive-card-shadow);
+  box-shadow: 0 4px 12px var(--color-card-shadow);
   transform: translateY(-1px);
 }
 
 .invite-link-copy:active {
   transform: translateY(0);
-  box-shadow: 0 2px 8px var(--executive-card-shadow);
+  box-shadow: 0 2px 8px var(--color-card-shadow);
 }
 
 .invite-link-copy:focus-visible {

--- a/src/components/about/myProfile.css
+++ b/src/components/about/myProfile.css
@@ -58,7 +58,7 @@
   color: var(--color-button-text);
   font-weight: 800;
   line-height: 1;
-  box-shadow: 0 2px 10px var(--executive-card-shadow);
+  box-shadow: 0 2px 10px var(--color-card-shadow);
   transition:
     background-color 160ms ease,
     box-shadow 160ms ease,
@@ -67,7 +67,7 @@
 
 .enroll-button:hover {
   background: var(--color-button-hover-bg);
-  box-shadow: 0 4px 16px var(--executive-card-shadow);
+  box-shadow: 0 4px 16px var(--color-card-shadow);
 }
 .enroll-button:active {
   transform: translateY(1px);
@@ -94,7 +94,7 @@
   text-decoration: none;
   font-weight: 800;
   line-height: 1.1;
-  box-shadow: 0 2px 10px var(--executive-card-shadow);
+  box-shadow: 0 2px 10px var(--color-card-shadow);
   transition:
     background-color 160ms ease,
     box-shadow 160ms ease,
@@ -105,7 +105,7 @@
 
 .action-button:hover {
   background: var(--color-button-hover-bg);
-  box-shadow: 0 4px 16px var(--executive-card-shadow);
+  box-shadow: 0 4px 16px var(--color-card-shadow);
 }
 .action-button:active {
   transform: translateY(1px);
@@ -278,7 +278,7 @@
 .dark .user-info-container,
 .dark .user-status-container,
 .dark .buttons-container {
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   color: var(--color-text-body);
-  box-shadow: 0 4px 20px var(--executive-card-shadow);
+  box-shadow: 0 4px 20px var(--color-card-shadow);
 }

--- a/src/components/board/SigTagManager.module.css
+++ b/src/components/board/SigTagManager.module.css
@@ -126,7 +126,7 @@
   padding: 0.6rem 0.95rem;
   border: 1px solid var(--color-text-subtle);
   border-radius: 0.7rem;
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   color: var(--color-text-body);
   font-weight: 600;
   cursor: pointer;

--- a/src/components/board/board.module.css
+++ b/src/components/board/board.module.css
@@ -14,7 +14,7 @@
 .sigCard {
   border: 1px solid var(--executive-name-color);
   border-radius: 0.75rem;
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   padding: 1rem 1.25rem;
   display: flex;
   flex-direction: column;
@@ -24,7 +24,7 @@
 }
 
 .sigCard:hover {
-  box-shadow: 0 2px 6px var(--executive-card-shadow);
+  box-shadow: 0 2px 6px var(--color-card-shadow);
 }
 
 .sigTopbar {
@@ -239,7 +239,7 @@
   border: 1px solid var(--color-border);
   border-radius: 0.9rem;
   overflow: hidden;
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   aspect-ratio: 1 / 1;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -170,7 +170,7 @@ img {
 }
 
 .LoadingCodeWrapper {
-  background-color: var(--executive-card-bg);
+  background-color: var(--color-card-bg);
   color: var(--color-text-strong);
   padding: 2rem;
   border-radius: 1rem;
@@ -354,7 +354,7 @@ button {
   all: unset;
   width: 100%;
   padding: 0.4em 0;
-  border-bottom: 3px solid var(--executive-card-bg);
+  border-bottom: 3px solid var(--color-card-bg);
 }
 .C_Input:focus {
   border-bottom: 3px solid var(--executive-overlay-bg);
@@ -375,7 +375,7 @@ button {
 }
 
 .PigUrlInput {
-  border-bottom: 2px solid var(--executive-card-bg);
+  border-bottom: 2px solid var(--color-card-bg);
   padding-bottom: 0.2em;
 }
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -23,6 +23,7 @@ html.theme-animating {
   --color-text-body: #2a2a2a;
   --color-text-subtle: #1b1b1b;
   --color-surface-light: #cccccc;
+  --color-editor-bg: rgb(202, 202, 202);
   --background-color: #b9c9d8;
   --foreground-color: #777;
   --header-background-color: var(--slate-1);
@@ -37,6 +38,7 @@ html.theme-animating {
   --primary-neon: #b0c4de;
   --dot-bg: #8ba1b6;
   --executive-card-bg: white;
+  --color-card-bg: white;
   --executive-overlay-bg: rgba(0, 0, 0, 0.55);
   --executive-name-color: #111;
   --executive-role-color: #444;
@@ -45,6 +47,7 @@ html.theme-animating {
   --executive-arrow-bg: #e0e0e0;
   --executive-arrow-hover: #ccc;
   --executive-card-shadow: rgba(0, 0, 0, 0.06);
+  --color-card-shadow: rgba(0, 0, 0, 0.06);
   --color-text-strong: #111111;
   --box-color: rgb(235, 235, 235);
   --selection-bg: #128e9f;
@@ -88,6 +91,7 @@ html.theme-animating {
   --color-text-body: #f5f5f5;
   --color-text-subtle: #aaaaaa;
   --color-surface-light: #2c2c2c;
+  --color-editor-bg: rgb(202, 202, 202);
   --background-color: #121212;
   --foreground-color: #e0e0e0;
   --header-background-color: #1a1a1a;
@@ -102,6 +106,7 @@ html.theme-animating {
   --primary-neon: #667799;
   --dot-bg: #555;
   --executive-card-bg: #1f1f1f;
+  --color-card-bg: #1f1f1f;
   --executive-overlay-bg: rgba(255, 255, 255, 0.08);
   --executive-name-color: #eee;
   --executive-role-color: #aaa;
@@ -110,6 +115,7 @@ html.theme-animating {
   --executive-arrow-bg: #333;
   --executive-arrow-hover: #444;
   --executive-card-shadow: rgba(255, 255, 255, 0.06);
+  --color-card-shadow: rgba(255, 255, 255, 0.06);
   --color-text-strong: #ffffff;
   --selection-bg: rgba(75, 176, 201, 0.35);
   --selection-text: #111111;


### PR DESCRIPTION
<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->

### What feature does this PR add?

<!-- Describe the feature or enhancement you implemented -->
fix #425 
--executive-card-bg 를 잘못 사용하고 있는 것들을 --color-card-bg로 바꿨습니다.
동일하게 --excutive-card-shadow 를 잘못 사용하고 있는 것들도 --color-card-bg로 바꿨습니다.
.mdxeditor에 5번 하드코딩 되어있던 색상을 theme.css에 --color-editor-bg를 추가하여 색을 불러오게 바꿨습니다.
.SigCreateBtn:hover:not(:disabled)에 있던 하드코딩된 색을 theme.css에서 --color-button-bg을 불러오도록 바꿨습니다.




---

### Are there any caveats or things to watch out for?

<!-- If none, write "None" -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Unified card, editor, and button styling to use new centralized theme tokens for consistent light/dark visuals.
  * Added explicit color tokens for card background, card shadow, and editor background; updated components/pages to use them.
  * Improved visual consistency across the app by replacing legacy theme variables with the new structured color system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->