### PR TITLE
✨관리자 페이지 html 관리에 다운로드 기능 추가

### DIFF
--- a/src/app/api/executive/w/[name]/download/route.js
+++ b/src/app/api/executive/w/[name]/download/route.js
@@ -1,0 +1,23 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/util/authOptions';
+
+export async function GET(_, { params }) {
+  const session = await getServerSession(authOptions);
+  const appJwt = session?.backendJwt || null;
+
+  const hdrs = {};
+  if (appJwt) hdrs['x-jwt'] = appJwt;
+
+  const res = await fetch(
+    `${process.env.BACKEND_URL || ''}/api/executive/w/${encodeURIComponent(
+      params['name'],
+    )}/download`,
+    {
+      method: 'GET',
+      headers: hdrs,
+      cache: 'no-store',
+    },
+  );
+
+  return res;
+}

--- a/src/app/api/executive/w/[name]/download/route.js
+++ b/src/app/api/executive/w/[name]/download/route.js
@@ -4,9 +4,12 @@ import { authOptions } from '@/util/authOptions';
 export async function GET(_, { params }) {
   const session = await getServerSession(authOptions);
   const appJwt = session?.backendJwt || null;
+  if (!appJwt) {
+    return Response.json({ detail: 'Unauthorized' }, { status: 401 });
+  }
 
   const hdrs = {};
-  if (appJwt) hdrs['x-jwt'] = appJwt;
+  hdrs['x-jwt'] = appJwt;
 
   const res = await fetch(
     `${process.env.BACKEND_URL || ''}/api/executive/w/${encodeURIComponent(

--- a/src/app/api/executive/w/[name]/download/route.js
+++ b/src/app/api/executive/w/[name]/download/route.js
@@ -19,5 +19,13 @@ export async function GET(_, { params }) {
     },
   );
 
-  return res;
+  const blob = await res.blob();
+  return new Response(blob, {
+    status: res.status,
+    headers: {
+      'Content-Type': res.headers.get('Content-Type') || 'text/html',
+      'Content-Disposition':
+        res.headers.get('Content-Disposition') || `attachment; filename="${params.name}.html"`,
+    },
+  });
 }

--- a/src/app/executive/page.css
+++ b/src/app/executive/page.css
@@ -130,6 +130,15 @@
   cursor: pointer;
 }
 
+.adm-button-danger {
+  padding: 0.5rem 0.9rem;
+  border: 1px solid var(--color-button-border);
+  border-radius: 8px;
+  background: var(--color-button-alert-bg);
+  color: var(--color-button-text);
+  font-weight: 600;
+  cursor: pointer;
+}
 .adm-button:disabled {
   opacity: 0.6;
   cursor: not-allowed;

--- a/src/app/executive/w/WList.jsx
+++ b/src/app/executive/w/WList.jsx
@@ -90,14 +90,29 @@ export default function WList({ wMetas }) {
   };
 
   const onClickDownload = async (name) => {
-    const res = await fetch(`/w/${encodeURIComponent(name)}`);
-    const blob = await res.blob();
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `${name}.html`;
-    a.click();
-    URL.revokeObjectURL(url);
+    if (isBusy) return;
+    setIsBusy(true);
+    try {
+      const res = await fetch(`/api/executive/w/${encodeURIComponent(name)}/download`);
+      if (!res.ok) throw new Error('download failed');
+
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      try {
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `${name}.html`;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+      } finally {
+        URL.revokeObjectURL(url);
+      }
+    } catch {
+      alert('다운로드 실패');
+    } finally {
+      setIsBusy(false);
+    }
   };
 
   return (

--- a/src/app/executive/w/WList.jsx
+++ b/src/app/executive/w/WList.jsx
@@ -89,9 +89,15 @@ export default function WList({ wMetas }) {
     }
   };
 
-  const onClickDownload = (name) => {
-    if (isBusy) return;
-    window.location.href = `/api/executive/w/${encodeURIComponent(name)}/download`;
+  const onClickDownload = async (name) => {
+    const res = await fetch(`/w/${encodeURIComponent(name)}`);
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${name}.html`;
+    a.click();
+    URL.revokeObjectURL(url);
   };
 
   return (

--- a/src/app/executive/w/WList.jsx
+++ b/src/app/executive/w/WList.jsx
@@ -89,6 +89,11 @@ export default function WList({ wMetas }) {
     }
   };
 
+  const onClickDownload = (name) => {
+    if (isBusy) return;
+    window.location.href = `/api/executive/w/${encodeURIComponent(name)}/download`;
+  };
+
   return (
     <div className={isBusy ? 'is-busy' : undefined}>
       <div className="adm-section">
@@ -103,6 +108,7 @@ export default function WList({ wMetas }) {
                 <th className="adm-th">생성시각</th>
                 <th className="adm-th">수정시각</th>
                 <th className="adm-th">수정버튼</th>
+                <th className="adm-th">다운로드버튼</th>
                 <th className="adm-th">삭제버튼</th>
               </tr>
             </thead>
@@ -127,7 +133,19 @@ export default function WList({ wMetas }) {
                   </td>
                   <td className="adm-td">
                     <button
+                      type="button"
                       className="adm-button"
+                      onClick={() => onClickDownload(w[0].name)}
+                      disabled={isBusy}
+                    >
+                      다운로드
+                    </button>
+                  </td>
+
+                  <td className="adm-td">
+                    <button
+                      type="button"
+                      className="adm-button-danger"
                       onClick={() => onClickDelete(w[0].name)}
                       disabled={isBusy}
                     >


### PR DESCRIPTION
### What feature does this PR add?
⚡ 임원 W 페이지 관리에서 다운로드 버튼 기능 수정

다운로드 버튼 클릭 시 백엔드 다운로드 API 엔드포인트를 거치는 대신, 기존에 존재하는 공개 엔드포인트 `/w/{name}`에서 파일을 가져온 뒤 임시 object URL을 생성하여 브라우저 다운로드를 트리거하는 방식으로 구현했습니다.

---
### Are there any caveats or things to watch out for?
다운로드가 공개 엔드포인트 `/w/{name}`에 의존하므로, 해당 엔드포인트가 제한되거나 삭제될 경우 다운로드 버튼이 동작하지 않을 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Download functionality for executive files via a new download action.
  * Download button added to the executive list interface (per-row, prevents multiple clicks while busy).
* **Style**
  * New danger button styling for alert/destructive actions.
* **Bug Fixes**
  * Download failures now show an alert message to the user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->