### PR TITLE
♻️ refactor: extract document links into constants

### DIFF
--- a/src/app/about/rules/page.jsx
+++ b/src/app/about/rules/page.jsx
@@ -1,12 +1,11 @@
 import ReactMarkdown from 'react-markdown';
+import { RULES_MARKDOWN_LINK } from '@/util/constants';
 import styles from '../about.module.css';
 
 export const dynamic = 'force-dynamic';
 
 async function fetchMarkdown() {
-  const url =
-    'https://raw.githubusercontent.com/scsc-init/homepage_init/master/%ED%9A%8C%EC%B9%99.md';
-  const res = await fetch(url, { cache: 'no-store' });
+  const res = await fetch(RULES_MARKDOWN_LINK, { cache: 'no-store' });
   if (!res.ok) {
     throw new Error('Failed to fetch regulation markdown.');
   }

--- a/src/app/us/fund-apply/create/FundApplyClient.jsx
+++ b/src/app/us/fund-apply/create/FundApplyClient.jsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
-import { SEMESTER_MAP } from '@/util/constants';
+import { FUND_APPLY_GUIDELINE_LINK, SEMESTER_MAP } from '@/util/constants';
 import { replaceLoginWithRedirect } from '@/util/loginRedirect';
 
 import './page.css';
@@ -18,9 +18,6 @@ const buildImageUrl = (id) => {
   if (!BACKEND_BASE_URL) return relative;
   return `${BACKEND_BASE_URL}${relative}`;
 };
-
-const GUIDE_URL =
-  'https://github.com/scsc-init/homepage_init/blob/master/%EC%9A%B4%EC%98%81%EB%B0%A9%EC%B9%A8/B_SCSC_%EC%A7%80%EC%9B%90%EA%B8%88_%EC%9A%B4%EC%98%81%EB%B0%A9%EC%B9%A8_%EB%B0%8F_%EC%8B%A0%EC%B2%AD%EC%A0%88%EC%B0%A8_%EC%84%B8%EC%B9%99.md';
 
 const PLACEHOLDER = {
   contest: `아래 항목을 참고해 상세 내용을 작성해주세요.
@@ -803,7 +800,12 @@ export default function FundApplyClient({
                     disabled={submitting}
                   />
                   <span className="C_CheckText">
-                    <a className="C_Link" href={GUIDE_URL} target="_blank" rel="noreferrer">
+                    <a
+                      className="C_Link"
+                      href={FUND_APPLY_GUIDELINE_LINK}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
                       SCSC 지원 가이드라인
                     </a>
                     을 확인했습니다.

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -65,7 +65,7 @@ export const KAKAO_INVITE_LINK = pickEnv(
  */
 export const RULES_MARKDOWN_LINK =
   'https://raw.githubusercontent.com/scsc-init/homepage_init/master/%ED%9A%8C%EC%B9%99.md';
-  
+
 /**
  * 지원금 신청 가이드라인 문서 링크입니다.
  */

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -60,6 +60,24 @@ export const KAKAO_INVITE_LINK = pickEnv(
   'https://invite.kakao.com/tc/II2yiLsQhY',
 );
 
+/**
+ * 회칙 마크다운 문서 링크입니다.
+ */
+export const RULES_MARKDOWN_LINK = pickEnv(
+  process.env.NEXT_PUBLIC_RULES_MARKDOWN_LINK,
+  process.env.RULES_MARKDOWN_LINK,
+  'https://raw.githubusercontent.com/scsc-init/homepage_init/master/%ED%9A%8C%EC%B9%99.md',
+);
+
+/**
+ * 지원금 신청 가이드라인 문서 링크입니다.
+ */
+export const FUND_APPLY_GUIDELINE_LINK = pickEnv(
+  process.env.NEXT_PUBLIC_FUND_APPLY_GUIDELINE_LINK,
+  process.env.FUND_APPLY_GUIDELINE_LINK,
+  'https://github.com/scsc-init/homepage_init/blob/master/%EC%9A%B4%EC%98%81%EB%B0%A9%EC%B9%A8/%EC%A7%80%EC%9B%90%EA%B8%88_%EC%8B%A0%EC%B2%AD_%EC%95%88%EB%82%B4%EC%82%AC%ED%95%AD.md',
+);
+
 export interface HeaderMenuItem {
   label: string;
   url: string;

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -65,7 +65,10 @@ export const KAKAO_INVITE_LINK = pickEnv(
  */
 export const RULES_MARKDOWN_LINK =
   'https://raw.githubusercontent.com/scsc-init/homepage_init/master/%ED%9A%8C%EC%B9%99.md';
-
+  
+/**
+ * 지원금 신청 가이드라인 문서 링크입니다.
+ */
 export const FUND_APPLY_GUIDELINE_LINK =
   'https://github.com/scsc-init/homepage_init/blob/master/%EC%9A%B4%EC%98%81%EB%B0%A9%EC%B9%A8/%EC%A7%80%EC%9B%90%EA%B8%88_%EC%8B%A0%EC%B2%AD_%EC%95%88%EB%82%B4%EC%82%AC%ED%95%AD.md';
 

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -63,20 +63,11 @@ export const KAKAO_INVITE_LINK = pickEnv(
 /**
  * 회칙 마크다운 문서 링크입니다.
  */
-export const RULES_MARKDOWN_LINK = pickEnv(
-  process.env.NEXT_PUBLIC_RULES_MARKDOWN_LINK,
-  process.env.RULES_MARKDOWN_LINK,
-  'https://raw.githubusercontent.com/scsc-init/homepage_init/master/%ED%9A%8C%EC%B9%99.md',
-);
+export const RULES_MARKDOWN_LINK =
+  'https://raw.githubusercontent.com/scsc-init/homepage_init/master/%ED%9A%8C%EC%B9%99.md';
 
-/**
- * 지원금 신청 가이드라인 문서 링크입니다.
- */
-export const FUND_APPLY_GUIDELINE_LINK = pickEnv(
-  process.env.NEXT_PUBLIC_FUND_APPLY_GUIDELINE_LINK,
-  process.env.FUND_APPLY_GUIDELINE_LINK,
-  'https://github.com/scsc-init/homepage_init/blob/master/%EC%9A%B4%EC%98%81%EB%B0%A9%EC%B9%A8/%EC%A7%80%EC%9B%90%EA%B8%88_%EC%8B%A0%EC%B2%AD_%EC%95%88%EB%82%B4%EC%82%AC%ED%95%AD.md',
-);
+export const FUND_APPLY_GUIDELINE_LINK =
+  'https://github.com/scsc-init/homepage_init/blob/master/%EC%9A%B4%EC%98%81%EB%B0%A9%EC%B9%A8/%EC%A7%80%EC%9B%90%EA%B8%88_%EC%8B%A0%EC%B2%AD_%EC%95%88%EB%82%B4%EC%82%AC%ED%95%AD.md';
 
 export interface HeaderMenuItem {
   label: string;


### PR DESCRIPTION
### What feature does this PR add?

♻️ 회칙 및 지원금 신청 가이드라인의 하드코딩된 외부 링크를 `@/util/constants.ts`로 분리했습니다.

- `about/rules` → `RULES_MARKDOWN_LINK` 사용
- `us/fund-apply/create` → `FUND_APPLY_GUIDELINE_LINK` 사용
- 상수에 JSDoc 주석 추가

문서 링크를 한 곳에서 관리할 수 있도록 정리한 리팩토링입니다.

---

### Are there any caveats or things to watch out for?
없음
Fixed #511