### PR TITLE
♻️관리자 sig 페이지 및 ig 상세 페이지 fetch 일원화

### DIFF
--- a/src/app/executive/sig/[id]/page.jsx
+++ b/src/app/executive/sig/[id]/page.jsx
@@ -14,18 +14,9 @@ export default async function ExecutiveSigPage({ params }) {
     return null;
   }
 
-  const [sigMembers, sigArticle] = await Promise.all([
-    safeFetch('GET', `/api/sig/${sigMeta.value.id}/members`),
-    sigMeta.value.content_id
-      ? safeFetch('GET', `/api/article/${sigMeta.value.content_id}`)
-      : Promise.resolve({ success: false, value: null }),
-  ]);
-
-  const sig = {
-    ...sigMeta.value,
-    content: sigArticle?.content ?? '',
-    members: Array.isArray(sigMembers) ? sigMembers : [],
-  };
+  const raw = sigMeta.value;
+  const sigContent = raw?.content?.content ?? raw?.content ?? '';
+  const sig = { ...raw, content: sigContent };
 
   return (
     <WithAuthorization>

--- a/src/app/pig/[id]/page.jsx
+++ b/src/app/pig/[id]/page.jsx
@@ -59,8 +59,7 @@ export default async function PigDetailPage({ params }) {
   }
   const pig = await pigRes.json();
 
-  const membersRes = await handleApiRequest('GET', `/api/pig/${id}/members`);
-  const rawMembers = membersRes.ok ? await membersRes.json() : [];
+  const rawMembers = pig.members ?? [];
   const members = Array.isArray(rawMembers)
     ? rawMembers.map((m) => m?.user ?? m).filter((user) => Boolean(user?.is_active))
     : [];

--- a/src/app/sig/[id]/page.jsx
+++ b/src/app/sig/[id]/page.jsx
@@ -59,8 +59,7 @@ export default async function SigDetailPage({ params }) {
   }
   const sig = await sigRes.json();
 
-  const membersRes = await handleApiRequest('GET', `/api/sig/${id}/members`);
-  const rawMembers = membersRes.ok ? await membersRes.json() : [];
+  const rawMembers = sig.members ?? [];
   const members = Array.isArray(rawMembers)
     ? rawMembers.map((m) => m?.user ?? m).filter((user) => Boolean(user?.is_active))
     : [];


### PR DESCRIPTION
<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->

### What feature does this PR add?

<!-- Describe the feature or enhancement you implemented -->

fixed #571
- 관리자 sig 페이지에서 members, article 개별 fetch -> sig.members, sig.article 사용
- sig 및 pig 상세 페이지에서 members 따로 fetch -> ig.members 사용

---

### Screenshots

<!--
If your changes affect the UI, please attach before/after screenshots.
If there is no UI change, write "None".
-->

PIG 상세 페이지 정상적으로 렌더링
<img width="1503" height="852" alt="image" src="https://github.com/user-attachments/assets/01deb044-1c49-419d-86e1-ecab0dc97093" />

---

### Are there any caveats or things to watch out for?

<!-- If none, write "None" -->
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized how member information is loaded on Special Interest Group and Product Interest Group detail pages, reducing unnecessary network requests and improving page performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->