### PR TITLE
🚑 fixed wrong redirection

### DIFF
--- a/src/app/api/auth/consume-redirect/route.js
+++ b/src/app/api/auth/consume-redirect/route.js
@@ -16,7 +16,6 @@ export function GET(request) {
   try {
     redirectUrl = new URL(target || '/', baseUrl);
   } catch {
-    // baseUrl was malformed; fall back to a safe absolute URL built from request.url
     redirectUrl = new URL(target || '/', request.url);
   }
 

--- a/src/app/api/auth/consume-redirect/route.js
+++ b/src/app/api/auth/consume-redirect/route.js
@@ -7,8 +7,18 @@ export function GET(request) {
   let target = null;
   if (raw) target = normalizeRedirectTarget(raw);
 
-  const baseUrl = process.env.NEXTAUTH_URL || request.url;
-  const redirectUrl = new URL(target || '/', baseUrl);
+  let baseUrl = process.env.NEXTAUTH_URL;
+  if (!baseUrl) {
+    console.warn('[consume-redirect] NEXTAUTH_URL is not set; falling back to request.url');
+    baseUrl = request.url;
+  }
+  let redirectUrl;
+  try {
+    redirectUrl = new URL(target || '/', baseUrl);
+  } catch {
+    // baseUrl was malformed; fall back to a safe absolute URL built from request.url
+    redirectUrl = new URL(target || '/', request.url);
+  }
 
   const res = NextResponse.redirect(redirectUrl);
 

--- a/src/app/api/auth/consume-redirect/route.js
+++ b/src/app/api/auth/consume-redirect/route.js
@@ -4,16 +4,11 @@ import { normalizeRedirectTarget } from '@/util/loginRedirect';
 export function GET(request) {
   const raw = request.cookies.get('redirect_after_login')?.value || null;
 
-  const responseUrl = new URL(request.url);
-  responseUrl.pathname = '/';
-  responseUrl.search = '';
-
   let target = null;
   if (raw) target = normalizeRedirectTarget(raw);
 
-  const redirectUrl = new URL(request.url);
-  redirectUrl.pathname = target || '/';
-  redirectUrl.search = '';
+  const baseUrl = process.env.NEXTAUTH_URL || request.url;
+  const redirectUrl = new URL(target || '/', baseUrl);
 
   const res = NextResponse.redirect(redirectUrl);
 


### PR DESCRIPTION
🐛 문제 원인

로그인된 상태에서 /us/login 접근 시,
/api/auth/consume-redirect에서 redirect URL을 생성할 때

new URL(request.url)

을 사용하고 있었음.

하지만 Next.js 서버 내부에서 request.url은
http://localhost:3000/... 형태로 들어오기 때문에,
이를 기반으로 생성된 redirect URL도 localhost로 설정됨.

그 결과, 로그인 후 또는 /us/login 재접속 시
사용자가 http://localhost:3000으로 리디렉션되는 문제가 발생함.

🔧 해결 방법

redirect URL 생성 시 request.url 대신
NEXTAUTH_URL을 기준으로 origin을 설정하도록 수정.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal redirect handling logic during authentication. No changes to user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


fixed #584