### PR TITLE
♻️Removing left over uneccesary fallback settings (fetchBackendClient / fetchBackendClientJson)

### DIFF
--- a/src/app/api/auth/login/route.js
+++ b/src/app/api/auth/login/route.js
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
-import { handleApiRequest } from '@/app/api/apiWrapper';
+import { fetchBackendServer } from '@/util/fetch/server';
 
 export async function POST(request) {
-  const res = await handleApiRequest('POST', '/api/user/login', {}, request);
+  const res = await fetchBackendServer('POST', '/api/user/login', {}, request);
 
   if (!res.ok) {
     return NextResponse.json({ error: 'login failed' }, { status: 400 });

--- a/src/app/api/test/users/route.js
+++ b/src/app/api/test/users/route.js
@@ -1,12 +1,12 @@
-import { handleApiRequest } from '@/app/api/apiWrapper';
+import { fetchBackendServer } from '@/util/fetch/server';
 import { ENABLE_TEST_UTILS } from '@/util/constants';
 
 export async function POST(request) {
   if (!ENABLE_TEST_UTILS) return new Response(null, { status: 404 });
-  return handleApiRequest('POST', '/api/test/users', {}, request);
+  return fetchBackendServer('POST', '/api/test/users', {}, request);
 }
 
 export async function DELETE() {
   if (!ENABLE_TEST_UTILS) return new Response(null, { status: 404 });
-  return handleApiRequest('DELETE', '/api/test/users');
+  return fetchBackendServer('DELETE', '/api/test/users', {});
 }

--- a/src/app/api/user/create/route.js
+++ b/src/app/api/user/create/route.js
@@ -1,5 +1,5 @@
-import { handleApiRequest } from '@/app/api/apiWrapper';
+import { fetchBackendServer } from '@/util/fetch/server';
 
 export async function POST(request) {
-  return handleApiRequest('POST', '/api/user/create', {}, request);
+  return fetchBackendServer('POST', '/api/user/create', {}, request);
 }

--- a/src/app/api/user/login/route.js
+++ b/src/app/api/user/login/route.js
@@ -1,5 +1,5 @@
-import { handleApiRequest } from '@/app/api/apiWrapper';
+import { fetchBackendServer } from '@/util/fetch/server';
 
 export async function POST(request) {
-  return handleApiRequest('POST', '/api/user/login', {}, request);
+  return fetchBackendServer('POST', '/api/user/login', {}, request);
 }

--- a/src/app/executive/DiscordBotPanel.jsx
+++ b/src/app/executive/DiscordBotPanel.jsx
@@ -5,13 +5,9 @@ import * as AdminLayout from '@/components/AdminLayout';
 
 export default function DiscordBotPanel({ is_logged_in }) {
   const discordLogin = async () => {
-    const res = await fetchBackendClient(
-      `/api/bot/discord/login`,
-      {
-        method: 'POST',
-      },
-      true,
-    );
+    const res = await fetchBackendClient(`/api/bot/discord/login`, {
+      method: 'POST',
+    });
     if (res.status === 204) alert('로그인 성공!');
     else alert(`로그인 실패: ${await res.text()}`);
   };

--- a/src/app/executive/IgMembersPanel.jsx
+++ b/src/app/executive/IgMembersPanel.jsx
@@ -171,7 +171,6 @@ export default function IgMembersPanel({ ig, users, is_sig, is_pig }) {
             user_id: u.id,
           }),
         },
-        true,
       );
       if (res.status === 204) {
         const newMember = { user_id: u.id, user: { id: u.id, email: u.email, name: u.name } };
@@ -206,7 +205,6 @@ export default function IgMembersPanel({ ig, users, is_sig, is_pig }) {
             user_id: member.user_id,
           }),
         },
-        true,
       );
       if (res.status === 204) {
         setMembers((prev) => prev.filter((m) => member.user_id !== m.user_id));

--- a/src/app/executive/ScscStatusPanel.jsx
+++ b/src/app/executive/ScscStatusPanel.jsx
@@ -42,15 +42,11 @@ export default function ScscStatusPanel({ scscGlobalStatus, semester, year }) {
 
   const handleConfirmSave = async () => {
     setSaving(true);
-    const res = await fetchBackendClient(
-      `/api/executive/scsc/global/status`,
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ status: selectedStatus }),
-      },
-      true,
-    );
+    const res = await fetchBackendClient(`/api/executive/scsc/global/status`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: selectedStatus }),
+    });
     if (res.status === 204) {
       alert('상태가 변경되었습니다.');
       setCurrentStatus(selectedStatus);

--- a/src/app/executive/board/ArticleList.jsx
+++ b/src/app/executive/board/ArticleList.jsx
@@ -11,14 +11,10 @@ export default function ArticleList({ boards: boardsDefault }) {
 
   useEffect(() => {
     async function fetchBoardArticles(boardId) {
-      const res = await fetchBackendClient(
-        `/api/articles/${boardId}`,
-        {
-          method: 'GET',
-          headers: { 'Content-Type': 'application/json' },
-        },
-        true,
-      );
+      const res = await fetchBackendClient(`/api/articles/${boardId}`, {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      });
       if (res.ok) return { [boardId]: await res.json() };
       return {};
     }
@@ -45,15 +41,11 @@ export default function ArticleList({ boards: boardsDefault }) {
 
   const saveBoard = async (board) => {
     try {
-      const res = await fetchBackendClient(
-        `/api/executive/board/update/${board.id}`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name: board.name }),
-        },
-        true,
-      );
+      const res = await fetchBackendClient(`/api/executive/board/update/${board.id}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: board.name }),
+      });
       if (res.status === 204) alert('게시판 이름 수정 완료');
       else alert('게시판 이름 수정 실패: ' + res.status);
     } catch (err) {
@@ -64,13 +56,9 @@ export default function ArticleList({ boards: boardsDefault }) {
       const ok = confirm('게시판을 삭제하시겠습니까?');
       if (!ok) return;
       try {
-        const res = await fetchBackendClient(
-          `/api/executive/board/delete/${id}`,
-          {
-            method: 'POST',
-          },
-          true,
-        );
+        const res = await fetchBackendClient(`/api/executive/board/delete/${id}`, {
+          method: 'POST',
+        });
         if (res.status === 204) {
           alert('삭제 완료');
           setBoards((prev) => prev.filter((b) => b.id !== id));
@@ -99,15 +87,11 @@ export default function ArticleList({ boards: boardsDefault }) {
       };
       try {
         setSaving((s) => ({ ...s, [article.id]: true }));
-        const res = await fetchBackendClient(
-          `/api/executive/article/update/${article.id}`,
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(payload),
-          },
-          true,
-        );
+        const res = await fetchBackendClient(`/api/executive/article/update/${article.id}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
         if (res.status === 204) alert('✅ 게시글 수정 완료');
         else {
           const error = await res.text();
@@ -124,13 +108,9 @@ export default function ArticleList({ boards: boardsDefault }) {
       const ok = confirm('정말 삭제하시겠습니까?');
       if (!ok) return;
       try {
-        const res = await fetchBackendClient(
-          `/api/executive/article/delete/${id}`,
-          {
-            method: 'POST',
-          },
-          true,
-        );
+        const res = await fetchBackendClient(`/api/executive/article/delete/${id}`, {
+          method: 'POST',
+        });
         if (res.status === 204) {
           setArticles((prev) => ({
             ...prev,

--- a/src/app/executive/major/MajorList.jsx
+++ b/src/app/executive/major/MajorList.jsx
@@ -13,28 +13,20 @@ export default function MajorList({ majors: majorsDefault }) {
   };
 
   const saveMajor = async (major) => {
-    const res = await fetchBackendClient(
-      `/api/executive/major/update/${major.id}`,
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(major),
-      },
-      true,
-    );
+    const res = await fetchBackendClient(`/api/executive/major/update/${major.id}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(major),
+    });
     if (res.status === 204) alert('저장 완료');
     else alert('저장 실패: ' + res.status);
   };
 
   const deleteMajor = async (id) => {
     if (!confirm('정말 삭제하시겠습니까?')) return;
-    const res = await fetchBackendClient(
-      `/api/executive/major/delete/${id}`,
-      {
-        method: 'POST',
-      },
-      true,
-    );
+    const res = await fetchBackendClient(`/api/executive/major/delete/${id}`, {
+      method: 'POST',
+    });
     if (res.status === 204) {
       alert('삭제 완료');
       setMajors((prev) => prev.filter((m) => m.id !== id));
@@ -42,15 +34,11 @@ export default function MajorList({ majors: majorsDefault }) {
   };
 
   const createMajor = async () => {
-    const res = await fetchBackendClient(
-      `/api/executive/major/create`,
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(newMajor),
-      },
-      true,
-    );
+    const res = await fetchBackendClient(`/api/executive/major/create`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(newMajor),
+    });
     if (res.status === 201) {
       setNewMajor({ college: '', major_name: '' });
       alert('추가 완료');

--- a/src/app/executive/pig/[id]/PigEdit.jsx
+++ b/src/app/executive/pig/[id]/PigEdit.jsx
@@ -155,24 +155,20 @@ export default function PigExecutiveEdit({ pig: _pig }) {
   const handleSave = async () => {
     try {
       setSaving(true);
-      const res1 = await fetchBackendClient(
-        `/api/executive/pig/${pig.id}/update`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            title: pig.title,
-            description: pig.description,
-            content: pig.content,
-            status: pig.status,
-            year: pig.year,
-            semester: pig.semester,
-            should_extend: Boolean(pig.should_extend),
-            is_rolling_admission: String(pig.is_rolling_admission),
-          }),
-        },
-        true,
-      );
+      const res1 = await fetchBackendClient(`/api/executive/pig/${pig.id}/update`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: pig.title,
+          description: pig.description,
+          content: pig.content,
+          status: pig.status,
+          year: pig.year,
+          semester: pig.semester,
+          should_extend: Boolean(pig.should_extend),
+          is_rolling_admission: String(pig.is_rolling_admission),
+        }),
+      });
       if (!res1.ok) {
         const msg1 = await res1.json();
         alert(`저장 실패. PIG 정보 수정: ${msg1?.detail ?? res1.status}`);
@@ -182,15 +178,11 @@ export default function PigExecutiveEdit({ pig: _pig }) {
 
       let res2 = null;
       if (selectedMember !== getLeaderUserId(pig)) {
-        res2 = await fetchBackendClient(
-          `/api/executive/pig/${pig.id}/handover`,
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ new_owner: selectedMember }),
-          },
-          true,
-        );
+        res2 = await fetchBackendClient(`/api/executive/pig/${pig.id}/handover`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ new_owner: selectedMember }),
+        });
       }
       if (!res2 || res2.ok) alert('저장 완료');
       else {
@@ -209,11 +201,9 @@ export default function PigExecutiveEdit({ pig: _pig }) {
     if (!confirm('정말 삭제하시겠습니까?')) return;
     try {
       setSaving(true);
-      const res = await fetchBackendClient(
-        `/api/executive/pig/${id}/delete`,
-        { method: 'POST' },
-        true,
-      );
+      const res = await fetchBackendClient(`/api/executive/pig/${id}/delete`, {
+        method: 'POST',
+      });
       if (res.status === 204) {
         router.replace('/executive/pig');
       } else {

--- a/src/app/executive/sig/[id]/SigEdit.jsx
+++ b/src/app/executive/sig/[id]/SigEdit.jsx
@@ -216,25 +216,21 @@ export default function SigExecutiveEdit({ sig: _sig }) {
   const handleSave = async () => {
     try {
       setSaving(true);
-      const res1 = await fetchBackendClient(
-        `/api/executive/sig/${sig.id}/update`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            title: sig.title,
-            description: sig.description,
-            content: sig.content,
-            status: sig.status,
-            year: sig.year,
-            semester: sig.semester,
-            should_extend: Boolean(sig.should_extend),
-            is_rolling_admission: Boolean(sig.is_rolling_admission),
-            websites: sanitizeWebsites(sig.websites),
-          }),
-        },
-        true,
-      );
+      const res1 = await fetchBackendClient(`/api/executive/sig/${sig.id}/update`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: sig.title,
+          description: sig.description,
+          content: sig.content,
+          status: sig.status,
+          year: sig.year,
+          semester: sig.semester,
+          should_extend: Boolean(sig.should_extend),
+          is_rolling_admission: Boolean(sig.is_rolling_admission),
+          websites: sanitizeWebsites(sig.websites),
+        }),
+      });
       if (!res1.ok) {
         const msg1 = await res1.json();
         alert(`저장 실패. SIG 정보 수정: ${msg1?.detail ?? res1.status}`);
@@ -246,15 +242,11 @@ export default function SigExecutiveEdit({ sig: _sig }) {
 
       let res2 = null;
       if (selectedMember !== getLeaderUserId(sig)) {
-        res2 = await fetchBackendClient(
-          `/api/executive/sig/${sig.id}/handover`,
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ new_owner: selectedMember }),
-          },
-          true,
-        );
+        res2 = await fetchBackendClient(`/api/executive/sig/${sig.id}/handover`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ new_owner: selectedMember }),
+        });
       }
       if (!res2 || res2.ok) alert('저장 완료');
       else {
@@ -273,11 +265,9 @@ export default function SigExecutiveEdit({ sig: _sig }) {
     if (!confirm('정말 삭제하시겠습니까?')) return;
     try {
       setSaving(true);
-      const res = await fetchBackendClient(
-        `/api/executive/sig/${id}/delete`,
-        { method: 'POST' },
-        true,
-      );
+      const res = await fetchBackendClient(`/api/executive/sig/${id}/delete`, {
+        method: 'POST',
+      });
       if (res.status === 204) {
         router.replace('/executive/sig');
       } else {

--- a/src/app/executive/user/LeadershipPanel.jsx
+++ b/src/app/executive/user/LeadershipPanel.jsx
@@ -77,18 +77,14 @@ export default function LeadershipPanel({ initialLeadership, candidates }) {
     }
     setPending(true);
     try {
-      const res = await fetchBackendClient(
-        '/api/executive/leadership',
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            president_id: presidentTrimmed || null,
-            vice_president_id: vicePresidentTrimmed || null,
-          }),
-        },
-        true,
-      );
+      const res = await fetchBackendClient('/api/executive/leadership', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          president_id: presidentTrimmed || null,
+          vice_president_id: vicePresidentTrimmed || null,
+        }),
+      });
 
       if (!res.ok) {
         const msg = await res.text();

--- a/src/app/executive/user/OldboyManagementPanel.jsx
+++ b/src/app/executive/user/OldboyManagementPanel.jsx
@@ -11,11 +11,7 @@ export default function OldboyManagementPanel({ users }) {
 
   useEffect(() => {
     const fetchApplicants = async () => {
-      const res = await fetchBackendClient(
-        `/api/executive/user/oldboy/applicants`,
-        undefined,
-        true,
-      );
+      const res = await fetchBackendClient(`/api/executive/user/oldboy/applicants`);
       if (res.ok) setApplicants(await res.json());
     };
     fetchApplicants();
@@ -23,13 +19,9 @@ export default function OldboyManagementPanel({ users }) {
 
   const processOldboy = async (user) => {
     setSaving((prev) => ({ ...prev, [user.id]: true }));
-    const res = await fetchBackendClient(
-      `/api/executive/user/oldboy/${user.id}/process`,
-      {
-        method: 'POST',
-      },
-      true,
-    );
+    const res = await fetchBackendClient(`/api/executive/user/oldboy/${user.id}/process`, {
+      method: 'POST',
+    });
     if (res.status === 204) alert(`${user.name} 졸업생 전환 승인 완료`);
     else {
       const err = await res.json();

--- a/src/app/executive/user/UserList.jsx
+++ b/src/app/executive/user/UserList.jsx
@@ -54,15 +54,11 @@ export function ReadUserTable({ users: usersDefault = [], majors = [] }) {
   const manualEnroll = async (user) => {
     setSaving((prev) => ({ ...prev, [user.id]: true }));
     try {
-      const res = await fetchBackendClient(
-        `/api/executive/user/standby/process/manual`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ id: user.id }),
-        },
-        true,
-      );
+      const res = await fetchBackendClient(`/api/executive/user/standby/process/manual`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: user.id }),
+      });
       if (res.status === 204) alert(`${user.name} 입금 확인 완료`);
       else alert(`${user.name} 입금 확인 실패: ${res.status}`);
     } finally {
@@ -230,15 +226,11 @@ export function ExecutiveUserTable({ users: usersDefault = [], majors = [], onSh
       is_active: user.is_active,
       is_banned: user.is_banned,
     };
-    const res = await fetchBackendClient(
-      `/api/executive/user/${user.id}`,
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(updated),
-      },
-      true,
-    );
+    const res = await fetchBackendClient(`/api/executive/user/${user.id}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(updated),
+    });
     if (res.status === 204) alert(`${user.name} 저장 완료`);
     else alert(`${user.name} 저장 실패: ${res.status}`);
     setSaving((prev) => ({ ...prev, [user.id]: false }));

--- a/src/app/executive/w/WList.jsx
+++ b/src/app/executive/w/WList.jsx
@@ -26,14 +26,10 @@ export default function WList({ wMetas }) {
       form.append('name', createName.trim());
     }
     try {
-      const res = await fetchBackendClient(
-        `/api/executive/w/create`,
-        {
-          method: 'POST',
-          body: form,
-        },
-        true,
-      );
+      const res = await fetchBackendClient(`/api/executive/w/create`, {
+        method: 'POST',
+        body: form,
+      });
       if (res.status !== 201) {
         const err = await res.json();
         alert('파일 처리 실패: ' + err.detail);

--- a/src/app/pig/[id]/PigDeleteButton.jsx
+++ b/src/app/pig/[id]/PigDeleteButton.jsx
@@ -26,14 +26,10 @@ export default function PigDeleteButton({ pigId, canDelete, isOwner }) {
   const deleteBySelf = async () => {
     try {
       setPending(true);
-      const res = await fetchBackendClient(
-        `/api/pig/${pigId}/delete`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-        },
-        true,
-      );
+      const res = await fetchBackendClient(`/api/pig/${pigId}/delete`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
       if (res.ok) {
         alert('PIG 비활성화 성공!');
         router.refresh();
@@ -50,14 +46,10 @@ export default function PigDeleteButton({ pigId, canDelete, isOwner }) {
   const deleteByExec = async () => {
     try {
       setPending(true);
-      const res = await fetchBackendClient(
-        `/api/pig/${pigId}/delete/executive`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-        },
-        true,
-      );
+      const res = await fetchBackendClient(`/api/pig/${pigId}/delete/executive`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
       if (res.ok) {
         alert('PIG 비활성화 성공!');
         router.refresh();

--- a/src/app/pig/[id]/PigJoinLeaveButton.jsx
+++ b/src/app/pig/[id]/PigJoinLeaveButton.jsx
@@ -29,14 +29,10 @@ export default function PigJoinLeaveButton({ pigId, initialIsMember = false }) {
   const join = async () => {
     try {
       setPending(true);
-      const res = await fetchBackendClient(
-        `/api/pig/${pigId}/member/join`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-        },
-        true,
-      );
+      const res = await fetchBackendClient(`/api/pig/${pigId}/member/join`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
       if (res.ok) {
         alert('PIG 가입 성공!');
         setIsMember(true);
@@ -54,14 +50,10 @@ export default function PigJoinLeaveButton({ pigId, initialIsMember = false }) {
   const leave = async () => {
     try {
       setPending(true);
-      const res = await fetchBackendClient(
-        `/api/pig/${pigId}/member/leave`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-        },
-        true,
-      );
+      const res = await fetchBackendClient(`/api/pig/${pigId}/member/leave`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
       if (res.ok) {
         alert('PIG 탈퇴 성공!');
         setIsMember(false);

--- a/src/app/pig/[id]/PigOwnerHandoverButton.jsx
+++ b/src/app/pig/[id]/PigOwnerHandoverButton.jsx
@@ -43,19 +43,15 @@ export default function PigOwnerHandoverButton({ pigId, members, owner }) {
     if (!window.confirm('정말 양도하시겠습니까?')) return;
     try {
       setPending(true);
-      const res = await fetchBackendClient(
-        `/api/pig/${pigId}/handover`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            new_owner: newOwner,
-          }),
+      const res = await fetchBackendClient(`/api/pig/${pigId}/handover`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
         },
-        true,
-      );
+        body: JSON.stringify({
+          new_owner: newOwner,
+        }),
+      });
 
       if (res.ok) {
         alert('PIG장 양도 성공!');

--- a/src/app/pig/edit/[id]/EditPigClient.jsx
+++ b/src/app/pig/edit/[id]/EditPigClient.jsx
@@ -114,22 +114,18 @@ export default function EditPigClient({ pigId, me, pig, article }) {
           ? `/api/pig/${pigId}/update/executive`
           : `/api/pig/${pigId}/update`;
 
-      const res = await fetchBackendClient(
-        endpoint,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            title: data.title,
-            description: data.description,
-            content: data.editor,
-            should_extend: data.should_extend,
-            is_rolling_admission: data.is_rolling_admission,
-            websites: sanitizeWebsites(data.websites),
-          }),
-        },
-        true,
-      );
+      const res = await fetchBackendClient(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: data.title,
+          description: data.description,
+          content: data.editor,
+          should_extend: data.should_extend,
+          is_rolling_admission: data.is_rolling_admission,
+          websites: sanitizeWebsites(data.websites),
+        }),
+      });
 
       if (res.status === 204) {
         isFormSubmitted.current = true;

--- a/src/app/sig/[id]/SigDeleteButton.jsx
+++ b/src/app/sig/[id]/SigDeleteButton.jsx
@@ -28,11 +28,7 @@ export default function SigDeleteButton({ sigId, canDelete, isOwner }) {
   const deleteBySelf = async () => {
     try {
       setPending(true);
-      const res = await fetchBackendClient(
-        `/api/sig/${sigId}/delete`,
-        { method: 'POST' },
-        true,
-      );
+      const res = await fetchBackendClient(`/api/sig/${sigId}/delete`, { method: 'POST' });
       if (res.ok) {
         alert('SIG 비활성화 성공!');
         router.refresh();
@@ -52,11 +48,9 @@ export default function SigDeleteButton({ sigId, canDelete, isOwner }) {
   const deleteByExec = async () => {
     try {
       setPending(true);
-      const res = await fetchBackendClient(
-        `/api/sig/${sigId}/delete/executive`,
-        { method: 'POST' },
-        true,
-      );
+      const res = await fetchBackendClient(`/api/sig/${sigId}/delete/executive`, {
+        method: 'POST',
+      });
       if (res.ok) {
         alert('SIG 비활성화 성공!');
         router.refresh();

--- a/src/app/sig/[id]/SigJoinLeaveButton.jsx
+++ b/src/app/sig/[id]/SigJoinLeaveButton.jsx
@@ -29,11 +29,7 @@ export default function SigJoinLeaveButton({ sigId, initialIsMember = false }) {
   const join = async () => {
     try {
       setPending(true);
-      const res = await fetchBackendClient(
-        `/api/sig/${sigId}/member/join`,
-        { method: 'POST' },
-        true,
-      );
+      const res = await fetchBackendClient(`/api/sig/${sigId}/member/join`, { method: 'POST' });
       if (res.ok) {
         alert('SIG 가입 성공!');
         setIsMember(true);
@@ -54,11 +50,9 @@ export default function SigJoinLeaveButton({ sigId, initialIsMember = false }) {
   const leave = async () => {
     try {
       setPending(true);
-      const res = await fetchBackendClient(
-        `/api/sig/${sigId}/member/leave`,
-        { method: 'POST' },
-        true,
-      );
+      const res = await fetchBackendClient(`/api/sig/${sigId}/member/leave`, {
+        method: 'POST',
+      });
       if (res.ok) {
         alert('SIG 탈퇴 성공!');
         setIsMember(false);

--- a/src/app/sig/[id]/SigOwnerHandoverButton.jsx
+++ b/src/app/sig/[id]/SigOwnerHandoverButton.jsx
@@ -43,19 +43,15 @@ export default function SigOwnerHandoverButton({ sigId, members, owner }) {
     if (!window.confirm('정말 양도하시겠습니까?')) return;
     try {
       setPending(true);
-      const res = await fetchBackendClient(
-        `/api/sig/${sigId}/handover`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            new_owner: newOwner,
-          }),
+      const res = await fetchBackendClient(`/api/sig/${sigId}/handover`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
         },
-        true,
-      );
+        body: JSON.stringify({
+          new_owner: newOwner,
+        }),
+      });
 
       if (res.ok) {
         alert('SIG장 양도 성공!');

--- a/src/app/sig/edit/[id]/EditSigClient.jsx
+++ b/src/app/sig/edit/[id]/EditSigClient.jsx
@@ -109,7 +109,6 @@ export default function EditSigClient({ sigId, me, sig, article }) {
             is_rolling_admission: data.is_rolling_admission,
           }),
         },
-        true,
       );
 
       if (res.status === 204) {

--- a/src/app/testutils/UserConsole.jsx
+++ b/src/app/testutils/UserConsole.jsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { fetchBackendClient } from '@/util/fetch/client';
 import styles from './page.module.css';
 
 export default function UserConsole() {
@@ -15,7 +14,7 @@ export default function UserConsole() {
 
 async function fetchDeleteAllUsers() {
   if (!confirm('정말 모든 유저를 삭제하시겠습니까?')) return;
-  const res = await fetchBackendClient('/api/test/users', { method: 'DELETE' }, true);
+  const res = await fetch('/api/test/users', { method: 'DELETE' });
   if (res.status === 204) alert('유저 삭제 성공');
   else alert(`유저 삭제 실패; status=${res.status}; msg=${await res.text()}`);
 }

--- a/src/app/us/(auth)/register/AuthClient.jsx
+++ b/src/app/us/(auth)/register/AuthClient.jsx
@@ -1,7 +1,6 @@
 // src/app/us/login/AuthClient.jsx
 'use client';
 
-import { fetchBackendClient } from '@/util/fetch/client';
 import { fetchMajors } from '@/util/fetch/client-util';
 import { useEffect, useState, useRef } from 'react';
 import '@/styles/theme.css';
@@ -90,7 +89,7 @@ export default function AuthClient() {
     const phone = `${form.phone1}${form.phone2}${form.phone3}`;
     const email = String(form.email || '').toLowerCase();
 
-    const createRes = await fetchBackendClient(
+    const createRes = await fetch(
       ENABLE_TEST_UTILS ? '/api/test/users' : `/api/user/create`,
       {
         method: 'POST',

--- a/src/app/us/edit-user-info/PfpUpdate.jsx
+++ b/src/app/us/edit-user-info/PfpUpdate.jsx
@@ -29,7 +29,7 @@ export default function PfpUpdate() {
 
   const handleSubmit = async () => {
     if (mode === 'url' && url) {
-      const res = await fetchBackendClient('/api/user/update', {
+      const res = await fetch('/api/user/update', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -48,7 +48,7 @@ export default function PfpUpdate() {
       const form = new FormData();
       form.append('file', file);
 
-      const res = await fetchBackendClient('/api/user/update-pfp-file', {
+      const res = await fetch('/api/user/update-pfp-file', {
         method: 'POST',
         body: form,
       });

--- a/src/app/us/edit-user-info/PfpUpdate.jsx
+++ b/src/app/us/edit-user-info/PfpUpdate.jsx
@@ -29,18 +29,14 @@ export default function PfpUpdate() {
 
   const handleSubmit = async () => {
     if (mode === 'url' && url) {
-      const res = await fetchBackendClient(
-        '/api/user/update',
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            profile_picture: url,
-            profile_picture_is_url: true,
-          }),
-        },
-        true,
-      );
+      const res = await fetchBackendClient('/api/user/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          profile_picture: url,
+          profile_picture_is_url: true,
+        }),
+      });
       if (res.status === 401) {
         alert('로그인이 필요합니다.');
         pushLoginWithRedirect(router);
@@ -52,14 +48,10 @@ export default function PfpUpdate() {
       const form = new FormData();
       form.append('file', file);
 
-      const res = await fetchBackendClient(
-        '/api/user/update-pfp-file',
-        {
-          method: 'POST',
-          body: form,
-        },
-        true,
-      );
+      const res = await fetchBackendClient('/api/user/update-pfp-file', {
+        method: 'POST',
+        body: form,
+      });
       if (res.status === 401) {
         alert('로그인이 필요합니다.');
         pushLoginWithRedirect(router);

--- a/src/app/us/edit-user-info/PfpUpdate.jsx
+++ b/src/app/us/edit-user-info/PfpUpdate.jsx
@@ -29,7 +29,7 @@ export default function PfpUpdate() {
 
   const handleSubmit = async () => {
     if (mode === 'url' && url) {
-      const res = await fetch('/api/user/update', {
+      const res = await fetchBackendClient('/api/user/update', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -48,7 +48,7 @@ export default function PfpUpdate() {
       const form = new FormData();
       form.append('file', file);
 
-      const res = await fetch('/api/user/update-pfp-file', {
+      const res = await fetchBackendClient('/api/user/update-pfp-file', {
         method: 'POST',
         body: form,
       });

--- a/src/components/board/AttachmentSection.jsx
+++ b/src/components/board/AttachmentSection.jsx
@@ -53,8 +53,6 @@ export default function AttachmentSection({
         const query = params.toString();
         const res = await fetchBackendClient(
           query ? `/api/file/metadata?${query}` : '/api/file/metadata',
-          undefined,
-          true,
         );
         const data = await res.json().catch(() => []);
         if (!res.ok) {
@@ -106,14 +104,10 @@ export default function AttachmentSection({
 
           let res;
           try {
-            res = await fetchBackendClient(
-              `/api/file/${uploadType}/upload`,
-              {
-                method: 'POST',
-                body: formData,
-              },
-              true,
-            );
+            res = await fetchBackendClient(`/api/file/${uploadType}/upload`, {
+              method: 'POST',
+              body: formData,
+            });
           } catch {
             alert('파일 업로드 중 네트워크 오류가 발생했습니다.');
             continue;

--- a/src/components/board/Comments.jsx
+++ b/src/components/board/Comments.jsx
@@ -46,19 +46,15 @@ function Comment({ comment, onReplySubmit, userId, userRole, articleId }) {
   const handleReply = async () => {
     if (!replyContent.trim()) return;
     try {
-      const res = await fetchBackendClient(
-        '/api/comments/create',
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            article_id: Number(articleId),
-            parent_id: comment.id,
-            content: replyContent,
-          }),
-        },
-        true,
-      );
+      const res = await fetchBackendClient('/api/comments/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          article_id: Number(articleId),
+          parent_id: comment.id,
+          content: replyContent,
+        }),
+      });
       if (res.ok) {
         setReplyContent('');
         setShowReply(false);
@@ -78,14 +74,10 @@ function Comment({ comment, onReplySubmit, userId, userRole, articleId }) {
           ? `/api/comments/${comment.id}/delete`
           : `/api/comments/${comment.id}/executive/delete`;
 
-      const res = await fetchBackendClient(
-        path,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-        },
-        true,
-      );
+      const res = await fetchBackendClient(path, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
 
       if (res.status === 204) onReplySubmit();
       else alert('댓글 삭제 실패: ' + (await readErrorText(res)));
@@ -179,19 +171,15 @@ export default function Comments({ articleId, initialComments, user }) {
   const submitNew = async () => {
     if (!newContent.trim()) return;
     try {
-      const res = await fetchBackendClient(
-        '/api/comments/create',
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            article_id: Number(articleId),
-            parent_id: null,
-            content: newContent,
-          }),
-        },
-        true,
-      );
+      const res = await fetchBackendClient('/api/comments/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          article_id: Number(articleId),
+          parent_id: null,
+          content: newContent,
+        }),
+      });
       if (res.ok) {
         setNewContent('');
         setShowNew(false);

--- a/src/components/board/GalleryView.jsx
+++ b/src/components/board/GalleryView.jsx
@@ -129,11 +129,10 @@ export default function GalleryView({ board, sortOrder }) {
       fetchedDetailRef.current = new Set();
 
       try {
-        const res = await fetchBackendClient(
-          listUrl,
-          { credentials: 'include', cache: 'no-store' },
-          true,
-        );
+        const res = await fetchBackendClient(listUrl, {
+          credentials: 'include',
+          cache: 'no-store',
+        });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
 
         const data = await res.json();
@@ -190,7 +189,6 @@ export default function GalleryView({ board, sortOrder }) {
               credentials: 'include',
               cache: 'no-store',
             },
-            true,
           );
           if (!res.ok) return { articleId: t.articleId, thumbSrc: '' };
 

--- a/src/components/board/MDXEditor.jsx
+++ b/src/components/board/MDXEditor.jsx
@@ -163,14 +163,10 @@ const InitializedMDXEditor = forwardRef(function InitializedMDXEditor(
 
     let res;
     try {
-      res = await fetchBackendClient(
-        '/api/file/image/upload',
-        {
-          method: 'POST',
-          body: formData,
-        },
-        true,
-      );
+      res = await fetchBackendClient('/api/file/image/upload', {
+        method: 'POST',
+        body: formData,
+      });
     } catch {
       alert('이미지 업로드 중 네트워크 오류가 발생했습니다.');
       return null;

--- a/src/components/board/SigTagManager.jsx
+++ b/src/components/board/SigTagManager.jsx
@@ -129,17 +129,13 @@ const SigTagManager = forwardRef(function SigTagManager(props, ref) {
     setLoading(true);
 
     try {
-      const res = await fetchBackendClient(
-        isExecutive ? '/api/executive/tag' : '/api/tag',
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(
-            isExecutive ? { text, is_major: Boolean(newTagIsMajor) } : { text },
-          ),
-        },
-        true,
-      );
+      const res = await fetchBackendClient(isExecutive ? '/api/executive/tag' : '/api/tag', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(
+          isExecutive ? { text, is_major: Boolean(newTagIsMajor) } : { text },
+        ),
+      });
 
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
@@ -185,13 +181,9 @@ const SigTagManager = forwardRef(function SigTagManager(props, ref) {
 
     try {
       const deleteRequests = removedTagIds.map(async (tagId) => {
-        const res = await fetchBackendClient(
-          `/api/sig/${sigId}/tag/${tagId}`,
-          {
-            method: 'DELETE',
-          },
-          true,
-        );
+        const res = await fetchBackendClient(`/api/sig/${sigId}/tag/${tagId}`, {
+          method: 'DELETE',
+        });
 
         if (!res.ok && res.status !== 204) {
           const err = await res.json().catch(() => ({}));
@@ -200,15 +192,11 @@ const SigTagManager = forwardRef(function SigTagManager(props, ref) {
       });
 
       const addRequests = addedTagIds.map(async (tagId) => {
-        const res = await fetchBackendClient(
-          `/api/sig/${sigId}/tag`,
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ tag_id: Number(tagId) }),
-          },
-          true,
-        );
+        const res = await fetchBackendClient(`/api/sig/${sigId}/tag`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tag_id: Number(tagId) }),
+        });
 
         if (!res.ok) {
           const err = await res.json().catch(() => ({}));


### PR DESCRIPTION


### What feature does this PR add?
fixed #614 


-각 호출부의 세 번째 인자인 true fallback 옵션을 제거했습니다.
-fallback 제거 후 남은 불필요한 undefined 인자도 함께 정리했습니다.
-API_SECRET 주입이 필요한 /api/user/create, /api/test/users 요청은 Next.js API route를 거치도록 일반 fetch 호출로 변경했습니다.

---

### Are there any caveats or things to watch out for?

<!-- If none, write "None" -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified and standardized API request usage across the app (uniform URL + options-object calls; some places now use direct fetch), improving consistency and request behavior.
* **Bug Fixes**
  * Fixed rolling-admission toggle to use the actual user-selected value instead of a hardcoded value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->