### PR TITLE
⚡ 모바일 프로필 페이지 로그아웃 버튼 중복 제거

### DIFF
--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -34,7 +34,7 @@ export default function HomePage() {
       <RefreshJWTClient />
 
       <div className="main-logo-wrapper">
-        <MainLogoImage className="main-logo logo" width={1976} height={670} loading="eager" />
+        <MainLogoImage className="main-logo logo" loading="eager" />
         <p className="main-logo-description">Seoul National University Computer Study Club</p>
       </div>
     </main>

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -1,5 +1,6 @@
 import './page.css';
 import RefreshJWTClient from './RefreshJWTClient';
+import { MainLogoImage } from '@/components/common/MainLogoImage';
 
 export default function HomePage() {
   return (
@@ -29,7 +30,13 @@ export default function HomePage() {
           />
         </picture>
       </div>
+
       <RefreshJWTClient />
+
+      <div className="main-logo-wrapper">
+        <MainLogoImage className="main-logo logo" loading="eager" />
+        <p className="main-logo-description">Seoul National University Computer Study Club</p>
+      </div>
     </main>
   );
 }

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -34,7 +34,7 @@ export default function HomePage() {
       <RefreshJWTClient />
 
       <div className="main-logo-wrapper">
-        <MainLogoImage className="main-logo logo" loading="eager" />
+        <MainLogoImage className="main-logo logo" width={1976} height={670} loading="eager" />
         <p className="main-logo-description">Seoul National University Computer Study Club</p>
       </div>
     </main>

--- a/src/components/about/MyProfileClient.jsx
+++ b/src/components/about/MyProfileClient.jsx
@@ -215,11 +215,6 @@ export default function MyProfileClient() {
               <span className="btn-label">로그아웃</span>
             </button>
           </div>
-          <div>
-            <button className="my-page-logout-button" onClick={handleLogout}>
-              로그아웃
-            </button>
-          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### What feature does this PR add?

* 모바일 환경의 프로필 페이지에서 로그아웃 버튼이 중복으로 표시되는 문제를 수정했습니다.
* 기존 버튼 목록 안의 로그아웃 버튼은 유지하고, 하단에 별도로 표시되던 중복 로그아웃 버튼을 제거했습니다.
* fixed #596

---

### Screenshots

Before
<img width="536" height="1036" alt="image" src="https://github.com/user-attachments/assets/d0a085fd-f31e-4d7f-9869-7d2cb1977937" />

After
<img width="539" height="1009" alt="image" src="https://github.com/user-attachments/assets/8edc2561-e42d-4ac6-9598-cd22d89c6324" />

---

### Are there any caveats or things to watch out for?

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a main logo section with descriptive caption to the homepage.

* **Style**
  * Updated the logout button with unified styling and icon integration for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->