### PR TITLE
⚡ 모바일 헤더 학기 표시 줄바꿈 방지

### DIFF
--- a/src/app/Header.module.css
+++ b/src/app/Header.module.css
@@ -33,6 +33,7 @@
 }
 
 .semesterLabel {
+  font-size: 0.875rem;
   white-space: nowrap;
   word-break: keep-all;
   flex-shrink: 0;

--- a/src/app/Header.module.css
+++ b/src/app/Header.module.css
@@ -32,6 +32,12 @@
   margin: 0 0.6rem;
 }
 
+.semesterLabel {
+  white-space: nowrap;
+  word-break: keep-all;
+  flex-shrink: 0;
+}
+
 .center {
   flex: 1;
   display: flex;

--- a/src/components/header/HeaderLeft.jsx
+++ b/src/components/header/HeaderLeft.jsx
@@ -17,7 +17,7 @@ export default function HeaderLeft({ year, semester }) {
         />
       </Link>
       {year && semester && (
-        <div className={styles.semesterLabel} style={{ fontSize: '0.875rem' }}>
+        <div className={styles.semesterLabel}>
           {year} - {SEMESTER_MAP[semester]}학기
         </div>
       )}

--- a/src/components/header/HeaderLeft.jsx
+++ b/src/components/header/HeaderLeft.jsx
@@ -17,7 +17,7 @@ export default function HeaderLeft({ year, semester }) {
         />
       </Link>
       {year && semester && (
-        <div style={{ fontSize: '0.875rem' }}>
+        <div className={styles.semesterLabel} style={{ fontSize: '0.875rem' }}>
           {year} - {SEMESTER_MAP[semester]}학기
         </div>
       )}


### PR DESCRIPTION
### What feature does this PR add?

* 모바일 환경에서 헤더의 학기 표시가 줄바꿈되는 문제를 수정했습니다.
* `2026 - 1학기`와 같은 학기 표시 텍스트가 한 줄로 유지되도록 `semesterLabel` 스타일을 추가했습니다.
* `white-space: nowrap`, `word-break: keep-all`, `flex-shrink: 0`을 적용해 모바일 헤더에서 학기 표시가 쪼개지지 않도록 했습니다.
fixed #590
---

### Screenshots

Before
<img width="968" height="1245" alt="image" src="https://github.com/user-attachments/assets/e0a94a59-22b3-425d-99f2-701ef38c1bdd" />

After
<img width="1016" height="1265" alt="image" src="https://github.com/user-attachments/assets/a8777b01-fe59-43dc-8400-4801f37bdfbb" />

---

### Are there any caveats or things to watch out for?

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved semester label styling in the header to prevent unwanted text wrapping and ensure consistent sizing across different layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->