### PR TITLE
♻️ board/[id]/create UI consistency improvement

### DIFF
--- a/src/components/board/WriteEditorAlbum.jsx
+++ b/src/components/board/WriteEditorAlbum.jsx
@@ -2,11 +2,14 @@
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import AttachmentSection from '@/components/board/AttachmentSection';
+import TextInput from '@/components/form-control/TextInput';
+import EditorInput from '@/components/form-control/EditorInput';
 
 export default function WriteEditorAlbum({ onSubmit, submitting, onDirtyChange }) {
   const {
     register,
     handleSubmit,
+    control,
     formState: { isDirty },
   } = useForm({
     defaultValues: { title: '', description: '' },
@@ -47,20 +50,13 @@ export default function WriteEditorAlbum({ onSubmit, submitting, onDirtyChange }
           />
         </div>
 
-        <div className="albumFieldGroup">
-          <label>앨범 제목</label>
-          <input
-            type="text"
-            {...register('title', { required: true })}
-            placeholder="앨범 제목 (예: 즐거운 워크샵 사진)"
-          />
-        </div>
-
-        <textarea
-          {...register('description')}
-          placeholder="Write a short description of the picture"
-          className="albumDescriptionInput"
+        <TextInput
+          label="앨범 제목"
+          placeholder="앨범 제목을 입력하세요 (예: 즐거운 워크샵 사진)"
+          register={register}
+          name="title"
         />
+        <EditorInput label="앨범 설명 (선택)" control={control} name="description" />
 
         <button type="submit" className="SigCreateBtn albumSubmitButton" disabled={submitting}>
           {submitting ? '업로드 중...' : '앨범 등록하기'}

--- a/src/components/board/WriteEditorStandard.jsx
+++ b/src/components/board/WriteEditorStandard.jsx
@@ -1,23 +1,20 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import dynamic from 'next/dynamic';
 import AttachmentSection from '@/components/board/AttachmentSection';
-
-const Editor = dynamic(() => import('@/components/board/EditorWrapper'), { ssr: false });
+import TextInput from '@/components/form-controls/TextInput';
+import EditorInput from '@/components/form-controls/EditorInput';
 
 export default function WriteEditorStandard({ onSubmit, submitting, onDirtyChange }) {
   const {
     register,
     handleSubmit,
-    setValue,
-    watch,
+    control,
     formState: { isDirty },
   } = useForm({
     defaultValues: { title: '', editor: '' },
   });
 
-  const content = watch('editor');
   const [attachmentIds, setAttachmentIds] = useState([]);
 
   useEffect(() => {
@@ -34,16 +31,13 @@ export default function WriteEditorStandard({ onSubmit, submitting, onDirtyChang
   return (
     <div className="CreateSigCard">
       <form onSubmit={handleSubmit(handleInternalSubmit)} className="createBoardForm">
-        <input
-          type="text"
-          {...register('title', { required: true })}
+        <TextInput
+          label="제목"
           placeholder="제목을 입력하세요"
+          register={register}
+          name="title"
         />
-
-        <Editor
-          markdown={content}
-          onChange={(value) => setValue('editor', value, { shouldDirty: true })}
-        />
+        <EditorInput label="내용" control={control} name="editor" />
         <AttachmentSection
           valueIds={attachmentIds}
           onChangeIds={setAttachmentIds}

--- a/src/components/board/WriteEditorStandard.jsx
+++ b/src/components/board/WriteEditorStandard.jsx
@@ -2,8 +2,8 @@
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import AttachmentSection from '@/components/board/AttachmentSection';
-import TextInput from '@/components/form-controls/TextInput';
-import EditorInput from '@/components/form-controls/EditorInput';
+import TextInput from '@/components/form-control/TextInput';
+import EditorInput from '@/components/form-control/EditorInput';
 
 export default function WriteEditorStandard({ onSubmit, submitting, onDirtyChange }) {
   const {


### PR DESCRIPTION
### What feature does this PR add?

fixed issue #622 

- `WriteEditorStandard.jsx`
  - 기존 native `<input>` 제목 입력을 `TextInput` 컴포넌트로 교체
  - `dynamic`으로 직접 불러오던 `Editor` 래퍼와 `watch`/`setValue` 수동 연결을 제거하고, `react-hook-form`의 `control`을 사용하는 `EditorInput` 컴포넌트로 교체
  
- `WriteEditorAlbum.jsx`
  - `albumFieldGroup`으로 감싸던 native `<input>` 제목 입력을 `TextInput` 컴포넌트로 교체
  - 앨범 설명용 `<textarea>`를 `EditorInput` 컴포넌트로 교체하여 일반 게시판과 동일하게끔 변경
  
---

### Screenshots
변경 후
<img width="749" height="712" alt="Screenshot 2026-06-13 at 6 14 38 PM" src="https://github.com/user-attachments/assets/d39cee2a-ee70-4e91-a176-22250ffe6da2" />

---

### Are there any caveats or things to watch out for?

<!-- If none, write "None" -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated form input components to use unified form-control components for consistency. Internal form management improved through standardized component patterns. No changes to user-facing functionality or appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->