### PR TITLE
🔧 로그인 세션 유지 시간 12h로 조정 및 env로 관리

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ src/
 | `GOOGLE_CLIENT_SECRET`     | 구글 OAuth 애플리케이션의 secret (하단의 `Google Auth 2.0 관리` 참조)                       |
 | `NEXTAUTH_SECRET`          | NextAuth 에 사용될 secret, 임의로 생성함 (하단의 `next auth 설정` 참조)                     |
 | `NEXTAUTH_URL`             | NextAuth 에 사용될 메인 URL, 프론트서버의 도메인 주소와 동일 (하단의 `next auth 설정` 참조) |
+| `JWT_VALID_SECONDS`        | 로그인 세션 유지 시간. 기본값은 43200초                                                     |
 | `SNU_EMAIL_CHECK`          | 디버깅용. 구글 OAuth로 회원가입 시 snu 도메인인지 체크 여부                                 |
 | `ENABLE_TEST_UTILS`        | 테스트 유틸리티 활성화 여부. TRUE로 설정했을 때만 활성화되며, 설정하지 않으면 비활성        |
 
@@ -102,6 +103,7 @@ GOOGLE_CLIENT_ID=구글_콘솔에서_받은_클라이언트_ID
 GOOGLE_CLIENT_SECRET=구글_콘솔에서_받은_클라이언트_SECRET
 NEXTAUTH_SECRET= openssl rand -base64 32 터미널에 입력해서 나온 값
 NEXTAUTH_URL=https://your-domain.com (로컬에서는 http://localhost:3000)
+JWT_VALID_SECONDS=43200
 SNU_EMAIL_CHECK=TRUE
 ```
 

--- a/src/util/authOptions.ts
+++ b/src/util/authOptions.ts
@@ -12,11 +12,27 @@ interface LoginResponseBody {
 const googleClientId = process.env.GOOGLE_CLIENT_ID ?? '';
 const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET ?? '';
 const apiSecret = process.env.API_SECRET ?? '';
+const DEFAULT_JWT_VALID_SECONDS = 12 * 60 * 60;
+const parseJwtValidSeconds = (value?: string) => {
+  if (!value?.trim()) {
+    return DEFAULT_JWT_VALID_SECONDS;
+  }
+
+  const seconds = Number(value);
+
+  if (!Number.isInteger(seconds) || seconds <= 0) {
+    return DEFAULT_JWT_VALID_SECONDS;
+  }
+
+  return seconds;
+};
+
+const jwtValidSeconds = parseJwtValidSeconds(process.env.JWT_VALID_SECONDS);
 
 export const authOptions: NextAuthOptions = {
   session: {
     strategy: 'jwt',
-    maxAge: 10 * 24 * 60 * 60,
+    maxAge: jwtValidSeconds,
   },
   providers: [
     Google({


### PR DESCRIPTION
### What feature does this PR add?

로그인 세션 유지 시간을 기존 10일에서 12시간으로 변경했습니다.
세션 유지 시간을 JWT_VALID_SECONDS 환경 변수로 관리할 수 있도록 수정했습니다.
README의 환경 변수 목록과 .env.local 예시에 JWT_VALID_SECONDS=43200 설정을 추가했습니다.

fixed #612 

### Screenshots

None

### Are there any caveats or things to watch out for?

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated environment variable documentation to include JWT session timeout setting.

* **Chores**
  * JWT session timeout duration is now configurable via environment variable with a 12-hour default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->