### PR TITLE
✨sig 생성시 태그 붙이기

### DIFF
--- a/src/app/api/executive/pig/[id]/delete/route.js
+++ b/src/app/api/executive/pig/[id]/delete/route.js
@@ -1,5 +1,5 @@
 import { handleApiRequest } from '@/app/api/apiWrapper';
 
 export async function POST(request, { params }) {
-  return handleApiRequest('POST', '/api/executive/pig/{id}/delete', { params });
+  return handleApiRequest('POST', '/api/executive/sig/{id}/delete', { params });
 }

--- a/src/app/api/executive/pig/[id]/handover/route.js
+++ b/src/app/api/executive/pig/[id]/handover/route.js
@@ -1,5 +1,5 @@
 import { handleApiRequest } from '@/app/api/apiWrapper';
 
 export async function POST(request, { params }) {
-  return handleApiRequest('POST', '/api/executive/pig/{id}/handover', { params }, request);
+  return handleApiRequest('POST', '/api/executive/sig/{id}/handover', { params }, request);
 }

--- a/src/app/api/executive/pig/[id]/member/join/route.js
+++ b/src/app/api/executive/pig/[id]/member/join/route.js
@@ -1,5 +1,5 @@
 import { handleApiRequest } from '@/app/api/apiWrapper';
 
 export async function POST(request, { params }) {
-  return handleApiRequest('POST', '/api/executive/pig/{id}/member/join', { params }, request);
+  return handleApiRequest('POST', '/api/executive/sig/{id}/member/join', { params }, request);
 }

--- a/src/app/api/executive/pig/[id]/member/leave/route.js
+++ b/src/app/api/executive/pig/[id]/member/leave/route.js
@@ -1,5 +1,5 @@
 import { handleApiRequest } from '@/app/api/apiWrapper';
 
 export async function POST(request, { params }) {
-  return handleApiRequest('POST', '/api/executive/pig/{id}/member/leave', { params }, request);
+  return handleApiRequest('POST', '/api/executive/sig/{id}/member/leave', { params }, request);
 }

--- a/src/app/api/executive/pig/[id]/update/route.js
+++ b/src/app/api/executive/pig/[id]/update/route.js
@@ -1,5 +1,5 @@
 import { handleApiRequest } from '@/app/api/apiWrapper';
 
 export async function POST(request, { params }) {
-  return handleApiRequest('POST', '/api/executive/pig/{id}/update', { params }, request);
+  return handleApiRequest('POST', '/api/executive/sig/{id}/update', { params }, request);
 }

--- a/src/app/api/pig/[id]/delete/executive/route.js
+++ b/src/app/api/pig/[id]/delete/executive/route.js
@@ -1,5 +1,5 @@
 import { handleApiRequest } from '@/app/api/apiWrapper';
 
 export async function POST(request, { params }) {
-  return handleApiRequest('POST', '/api/executive/pig/{id}/delete', { params });
+  return handleApiRequest('POST', '/api/executive/sig/{id}/delete', { params });
 }

--- a/src/app/api/pig/[id]/delete/route.js
+++ b/src/app/api/pig/[id]/delete/route.js
@@ -1,5 +1,5 @@
 import { handleApiRequest } from '@/app/api/apiWrapper';
 
 export async function POST(request, { params }) {
-  return handleApiRequest('POST', '/api/pig/{id}/delete', { params });
+  return handleApiRequest('POST', '/api/sig/{id}/delete', { params });
 }

--- a/src/app/api/pig/[id]/handover/route.js
+++ b/src/app/api/pig/[id]/handover/route.js
@@ -1,5 +1,5 @@
 import { handleApiRequest } from '@/app/api/apiWrapper';
 
 export async function POST(request, { params }) {
-  return handleApiRequest('POST', '/api/pig/{id}/handover', { params }, request);
+  return handleApiRequest('POST', '/api/sig/{id}/handover', { params }, request);
 }

--- a/src/app/api/pig/[id]/member/join/route.js
+++ b/src/app/api/pig/[id]/member/join/route.js
@@ -1,5 +1,5 @@
 import { handleApiRequest } from '@/app/api/apiWrapper';
 
 export async function POST(request, { params }) {
-  return handleApiRequest('POST', '/api/pig/{id}/member/join', { params });
+  return handleApiRequest('POST', '/api/sig/{id}/member/join', { params });
 }

--- a/src/app/api/pig/[id]/member/leave/route.js
+++ b/src/app/api/pig/[id]/member/leave/route.js
@@ -1,5 +1,5 @@
 import { handleApiRequest } from '@/app/api/apiWrapper';
 
 export async function POST(request, { params }) {
-  return handleApiRequest('POST', '/api/pig/{id}/member/leave', { params });
+  return handleApiRequest('POST', '/api/sig/{id}/member/leave', { params });
 }

--- a/src/app/api/pig/[id]/update/executive/route.js
+++ b/src/app/api/pig/[id]/update/executive/route.js
@@ -1,5 +1,5 @@
 import { handleApiRequest } from '@/app/api/apiWrapper';
 
 export async function POST(request, { params }) {
-  return handleApiRequest('POST', '/api/executive/pig/{id}/update', { params }, request);
+  return handleApiRequest('POST', '/api/executive/sig/{id}/update', { params }, request);
 }

--- a/src/app/api/pig/[id]/update/route.js
+++ b/src/app/api/pig/[id]/update/route.js
@@ -1,5 +1,5 @@
 import { handleApiRequest } from '@/app/api/apiWrapper';
 
 export async function POST(request, { params }) {
-  return handleApiRequest('POST', '/api/pig/{id}/update', { params }, request);
+  return handleApiRequest('POST', '/api/sig/{id}/update', { params }, request);
 }

--- a/src/app/api/pig/create/route.js
+++ b/src/app/api/pig/create/route.js
@@ -1,5 +1,5 @@
 import { handleApiRequest } from '@/app/api/apiWrapper';
 
 export async function POST(request) {
-  return handleApiRequest('POST', '/api/pig/create', {}, request);
+  return handleApiRequest('POST', '/api/sig/create', {}, request);
 }

--- a/src/app/executive/pig/[id]/PigEdit.jsx
+++ b/src/app/executive/pig/[id]/PigEdit.jsx
@@ -155,7 +155,7 @@ export default function PigExecutiveEdit({ pig: _pig }) {
   const handleSave = async () => {
     try {
       setSaving(true);
-      const res1 = await fetchBackendClient(`/api/executive/pig/${pig.id}/update`, {
+      const res1 = await fetchBackendClient(`/api/executive/sig/${pig.id}/update`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -178,7 +178,7 @@ export default function PigExecutiveEdit({ pig: _pig }) {
 
       let res2 = null;
       if (selectedMember !== getLeaderUserId(pig)) {
-        res2 = await fetchBackendClient(`/api/executive/pig/${pig.id}/handover`, {
+        res2 = await fetchBackendClient(`/api/executive/sig/${pig.id}/handover`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ new_owner: selectedMember }),
@@ -201,7 +201,7 @@ export default function PigExecutiveEdit({ pig: _pig }) {
     if (!confirm('정말 삭제하시겠습니까?')) return;
     try {
       setSaving(true);
-      const res = await fetchBackendClient(`/api/executive/pig/${id}/delete`, {
+      const res = await fetchBackendClient(`/api/executive/sig/${id}/delete`, {
         method: 'POST',
       });
       if (res.status === 204) {

--- a/src/app/executive/pig/[id]/page.jsx
+++ b/src/app/executive/pig/[id]/page.jsx
@@ -8,7 +8,7 @@ import * as AdminLayout from '@/components/AdminLayout';
 
 export default async function ExecutivePigPage({ params }) {
   const [pigMeta, users] = await Promise.allSettled([
-    fetchBackendServerJson('GET', `/api/pig/${(await params).id}`),
+    fetchBackendServerJson('GET', `/api/sig/${(await params).id}`),
     fetchUsers(),
   ]);
   if (pigMeta.status !== 'fulfilled') {

--- a/src/app/executive/pig/page.jsx
+++ b/src/app/executive/pig/page.jsx
@@ -7,7 +7,7 @@ import * as AdminLayout from '@/components/AdminLayout';
 
 export default async function ExecutivePigPage() {
   const [pigMetas, users] = await Promise.allSettled([
-    fetchBackendServerJson('GET', '/api/pigs'),
+    fetchBackendServerJson('GET', '/api/sigs', { query: { tag: 'PIG' } }),
     fetchUsers(),
   ]);
   if (pigMetas.status !== 'fulfilled' || users.status !== 'fulfilled') return null;

--- a/src/app/executive/sig/page.jsx
+++ b/src/app/executive/sig/page.jsx
@@ -7,7 +7,7 @@ import * as AdminLayout from '@/components/AdminLayout';
 
 export default async function ExecutiveSigPage() {
   const [sigMetas, users] = await Promise.allSettled([
-    fetchBackendServerJson('GET', '/api/sigs'),
+    fetchBackendServerJson('GET', '/api/sigs', { query: { tag: 'SIG' } }),
     fetchUsers(),
   ]);
   if (sigMetas.status !== 'fulfilled' || users.status !== 'fulfilled') return null;

--- a/src/app/pig/[id]/PigDeleteButton.jsx
+++ b/src/app/pig/[id]/PigDeleteButton.jsx
@@ -26,7 +26,7 @@ export default function PigDeleteButton({ pigId, canDelete, isOwner }) {
   const deleteBySelf = async () => {
     try {
       setPending(true);
-      const res = await fetchBackendClient(`/api/pig/${pigId}/delete`, {
+      const res = await fetchBackendClient(`/api/sig/${pigId}/delete`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
       });
@@ -46,7 +46,7 @@ export default function PigDeleteButton({ pigId, canDelete, isOwner }) {
   const deleteByExec = async () => {
     try {
       setPending(true);
-      const res = await fetchBackendClient(`/api/pig/${pigId}/delete/executive`, {
+      const res = await fetchBackendClient(`/api/sig/${pigId}/delete/executive`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
       });

--- a/src/app/pig/[id]/PigJoinLeaveButton.jsx
+++ b/src/app/pig/[id]/PigJoinLeaveButton.jsx
@@ -29,7 +29,7 @@ export default function PigJoinLeaveButton({ pigId, initialIsMember = false }) {
   const join = async () => {
     try {
       setPending(true);
-      const res = await fetchBackendClient(`/api/pig/${pigId}/member/join`, {
+      const res = await fetchBackendClient(`/api/sig/${pigId}/member/join`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
       });
@@ -50,7 +50,7 @@ export default function PigJoinLeaveButton({ pigId, initialIsMember = false }) {
   const leave = async () => {
     try {
       setPending(true);
-      const res = await fetchBackendClient(`/api/pig/${pigId}/member/leave`, {
+      const res = await fetchBackendClient(`/api/sig/${pigId}/member/leave`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
       });

--- a/src/app/pig/[id]/PigOwnerHandoverButton.jsx
+++ b/src/app/pig/[id]/PigOwnerHandoverButton.jsx
@@ -43,7 +43,7 @@ export default function PigOwnerHandoverButton({ pigId, members, owner }) {
     if (!window.confirm('정말 양도하시겠습니까?')) return;
     try {
       setPending(true);
-      const res = await fetchBackendClient(`/api/pig/${pigId}/handover`, {
+      const res = await fetchBackendClient(`/api/sig/${pigId}/handover`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/app/pig/[id]/page.jsx
+++ b/src/app/pig/[id]/page.jsx
@@ -6,7 +6,7 @@ import { fetchBackendServer, fetchBackendServerJson } from '@/util/fetch/server'
 export async function generateMetadata({ params }) {
   const { id } = await params;
   try {
-    const pig = await fetchBackendServerJson('GET', `/api/pig/${id}`);
+    const pig = await fetchBackendServerJson('GET', `/api/sig/${id}`);
     return {
       title: pig.title,
       description: pig.description || 'PIG 상세 페이지',
@@ -42,7 +42,7 @@ export async function generateMetadata({ params }) {
 export default async function PigDetailPage({ params }) {
   const { id } = await params;
 
-  const pigRes = await fetchBackendServer('GET', `/api/pig/${id}`);
+  const pigRes = await fetchBackendServer('GET', `/api/sig/${id}`);
   if (!pigRes.ok) {
     return <div className="p-6 text-center text-red-600">존재하지 않는 PIG입니다.</div>;
   }

--- a/src/app/pig/create/CreatePigClient.jsx
+++ b/src/app/pig/create/CreatePigClient.jsx
@@ -119,6 +119,7 @@ export default function CreatePigClient({ scscGlobalStatus }) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           title: data.title,
+          major_tag: 'PIG',
           description: data.description,
           content: data.editor,
           is_rolling_admission: data.is_rolling_admission,
@@ -127,43 +128,6 @@ export default function CreatePigClient({ scscGlobalStatus }) {
       });
 
       if (res.status === 201) {
-        const createdPig = await res.json().catch(() => null);
-        const createdPigId = createdPig?.id;
-
-        if (createdPigId == null) {
-          throw new Error('생성 응답에 PIG ID가 없습니다.');
-        }
-
-        const tagsRes = await fetchBackendClient('/api/tags', { cache: 'no-store' });
-        if (!tagsRes.ok) {
-          const err = await tagsRes.json().catch(() => ({}));
-          throw new Error(err.detail ?? '태그 목록을 불러오지 못했습니다.');
-        }
-
-        const tags = await tagsRes.json().catch(() => []);
-        const majorTag = (Array.isArray(tags) ? tags : []).find(
-          (tag) =>
-            tag?.is_major &&
-            String(tag?.text ?? '')
-              .trim()
-              .toUpperCase() === 'PIG',
-        );
-
-        if (!majorTag?.id) {
-          throw new Error('PIG 메이저 태그를 찾을 수 없습니다.');
-        }
-
-        const attachRes = await fetchBackendClient(`/api/sig/${createdPigId}/tag`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ tag_id: Number(majorTag.id) }),
-        });
-
-        if (!attachRes.ok) {
-          const err = await attachRes.json().catch(() => ({}));
-          throw new Error(err.detail ?? 'PIG 메이저 태그를 붙이지 못했습니다.');
-        }
-
         isFormSubmitted.current = true;
         sessionStorage.removeItem('pigForm');
         alert('PIG 생성 성공!');

--- a/src/app/pig/create/CreatePigClient.jsx
+++ b/src/app/pig/create/CreatePigClient.jsx
@@ -127,9 +127,46 @@ export default function CreatePigClient({ scscGlobalStatus }) {
       });
 
       if (res.status === 201) {
-        alert('PIG 생성 성공!');
+        const createdPig = await res.json().catch(() => null);
+        const createdPigId = createdPig?.id;
+
+        if (createdPigId == null) {
+          throw new Error('생성 응답에 PIG ID가 없습니다.');
+        }
+
+        const tagsRes = await fetchBackendClient('/api/tags', { cache: 'no-store' });
+        if (!tagsRes.ok) {
+          const err = await tagsRes.json().catch(() => ({}));
+          throw new Error(err.detail ?? '태그 목록을 불러오지 못했습니다.');
+        }
+
+        const tags = await tagsRes.json().catch(() => []);
+        const majorTag = (Array.isArray(tags) ? tags : []).find(
+          (tag) =>
+            tag?.is_major &&
+            String(tag?.text ?? '')
+              .trim()
+              .toUpperCase() === 'PIG',
+        );
+
+        if (!majorTag?.id) {
+          throw new Error('PIG 메이저 태그를 찾을 수 없습니다.');
+        }
+
+        const attachRes = await fetchBackendClient(`/api/sig/${createdPigId}/tag`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tag_id: Number(majorTag.id) }),
+        });
+
+        if (!attachRes.ok) {
+          const err = await attachRes.json().catch(() => ({}));
+          throw new Error(err.detail ?? 'PIG 메이저 태그를 붙이지 못했습니다.');
+        }
+
         isFormSubmitted.current = true;
         sessionStorage.removeItem('pigForm');
+        alert('PIG 생성 성공!');
         router.push('/pig');
         router.refresh();
       } else if (res.status === 401) {

--- a/src/app/pig/create/CreatePigClient.jsx
+++ b/src/app/pig/create/CreatePigClient.jsx
@@ -119,7 +119,7 @@ export default function CreatePigClient({ scscGlobalStatus }) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           title: data.title,
-          major_tag: 'PIG',
+          tags: ['PIG'],
           description: data.description,
           content: data.editor,
           is_rolling_admission: data.is_rolling_admission,

--- a/src/app/pig/create/CreatePigClient.jsx
+++ b/src/app/pig/create/CreatePigClient.jsx
@@ -114,7 +114,7 @@ export default function CreatePigClient({ scscGlobalStatus }) {
     setSubmitting(true);
 
     try {
-      const res = await fetchBackendClient(`/api/pig/create`, {
+      const res = await fetchBackendClient(`/api/sig/create`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/src/app/pig/edit/[id]/EditPigClient.jsx
+++ b/src/app/pig/edit/[id]/EditPigClient.jsx
@@ -117,8 +117,8 @@ export default function EditPigClient({ pigId, pig, article }) {
     try {
       const endpoint =
         me.role >= minExecutiveLevel
-          ? `/api/pig/${pigId}/update/executive`
-          : `/api/pig/${pigId}/update`;
+          ? `/api/sig/${pigId}/update/executive`
+          : `/api/sig/${pigId}/update`;
 
       const res = await fetchBackendClient(endpoint, {
         method: 'POST',

--- a/src/app/pig/edit/[id]/page.jsx
+++ b/src/app/pig/edit/[id]/page.jsx
@@ -9,7 +9,7 @@ export default async function EditPigPage({ params }) {
 
   let pig;
   try {
-    pig = await fetchBackendServerJson('GET', `/api/pig/${id}`);
+    pig = await fetchBackendServerJson('GET', `/api/sig/${id}`);
   } catch {
     return (
       <div className="CreatePigContainer">

--- a/src/app/pig/page.jsx
+++ b/src/app/pig/page.jsx
@@ -5,7 +5,9 @@ import { fetchBackendServerJson } from '@/util/fetch/server';
 export const metadata = { title: 'PIG' };
 
 export default async function PigListPage() {
-  const pigs = await fetchBackendServerJson('GET', '/api/pigs').then(
+  const pigs = await fetchBackendServerJson('GET', '/api/sigs', {
+    query: { tag: 'PIG' },
+  }).then(
     (value) => ({ status: 'fulfilled', value }),
     (reason) => ({ status: 'rejected', reason }),
   );

--- a/src/app/sig/create/CreateSigClient.jsx
+++ b/src/app/sig/create/CreateSigClient.jsx
@@ -124,6 +124,7 @@ export default function CreateSigClient({ scscGlobalStatus }) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           title: data.title,
+          major_tag: 'SIG',
           description: data.description,
           content: data.editor,
           is_rolling_admission: data.is_rolling_admission,
@@ -132,43 +133,6 @@ export default function CreateSigClient({ scscGlobalStatus }) {
       });
 
       if (res.status === 201) {
-        const createdSig = await res.json().catch(() => null);
-        const createdSigId = createdSig?.id;
-
-        if (createdSigId == null) {
-          throw new Error('생성 응답에 SIG ID가 없습니다.');
-        }
-
-        const tagsRes = await fetchBackendClient('/api/tags', { cache: 'no-store' });
-        if (!tagsRes.ok) {
-          const err = await tagsRes.json().catch(() => ({}));
-          throw new Error(err.detail ?? '태그 목록을 불러오지 못했습니다.');
-        }
-
-        const tags = await tagsRes.json().catch(() => []);
-        const majorTag = (Array.isArray(tags) ? tags : []).find(
-          (tag) =>
-            tag?.is_major &&
-            String(tag?.text ?? '')
-              .trim()
-              .toUpperCase() === 'SIG',
-        );
-
-        if (!majorTag?.id) {
-          throw new Error('SIG 메이저 태그를 찾을 수 없습니다.');
-        }
-
-        const attachRes = await fetchBackendClient(`/api/sig/${createdSigId}/tag`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ tag_id: Number(majorTag.id) }),
-        });
-
-        if (!attachRes.ok) {
-          const err = await attachRes.json().catch(() => ({}));
-          throw new Error(err.detail ?? 'SIG 메이저 태그를 붙이지 못했습니다.');
-        }
-
         isFormSubmitted.current = true;
         sessionStorage.removeItem('sigForm');
         alert('SIG 생성 성공!');

--- a/src/app/sig/create/CreateSigClient.jsx
+++ b/src/app/sig/create/CreateSigClient.jsx
@@ -132,9 +132,46 @@ export default function CreateSigClient({ scscGlobalStatus }) {
       });
 
       if (res.status === 201) {
-        alert('SIG 생성 성공!');
+        const createdSig = await res.json().catch(() => null);
+        const createdSigId = createdSig?.id;
+
+        if (createdSigId == null) {
+          throw new Error('생성 응답에 SIG ID가 없습니다.');
+        }
+
+        const tagsRes = await fetchBackendClient('/api/tags', { cache: 'no-store' });
+        if (!tagsRes.ok) {
+          const err = await tagsRes.json().catch(() => ({}));
+          throw new Error(err.detail ?? '태그 목록을 불러오지 못했습니다.');
+        }
+
+        const tags = await tagsRes.json().catch(() => []);
+        const majorTag = (Array.isArray(tags) ? tags : []).find(
+          (tag) =>
+            tag?.is_major &&
+            String(tag?.text ?? '')
+              .trim()
+              .toUpperCase() === 'SIG',
+        );
+
+        if (!majorTag?.id) {
+          throw new Error('SIG 메이저 태그를 찾을 수 없습니다.');
+        }
+
+        const attachRes = await fetchBackendClient(`/api/sig/${createdSigId}/tag`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tag_id: Number(majorTag.id) }),
+        });
+
+        if (!attachRes.ok) {
+          const err = await attachRes.json().catch(() => ({}));
+          throw new Error(err.detail ?? 'SIG 메이저 태그를 붙이지 못했습니다.');
+        }
+
         isFormSubmitted.current = true;
         sessionStorage.removeItem('sigForm');
+        alert('SIG 생성 성공!');
         router.push('/sig');
         router.refresh();
       } else if (res.status === 401) {

--- a/src/app/sig/create/CreateSigClient.jsx
+++ b/src/app/sig/create/CreateSigClient.jsx
@@ -124,7 +124,7 @@ export default function CreateSigClient({ scscGlobalStatus }) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           title: data.title,
-          major_tag: 'SIG',
+          tags: ['SIG'],
           description: data.description,
           content: data.editor,
           is_rolling_admission: data.is_rolling_admission,

--- a/src/app/sig/page.jsx
+++ b/src/app/sig/page.jsx
@@ -14,7 +14,9 @@ export default async function SigListPage({ searchParams }) {
     initialTags = [resolvedSearchParams.tag];
   }
 
-  const sigs = await fetchBackendServerJson('GET', '/api/sigs').then(
+  const sigs = await fetchBackendServerJson('GET', '/api/sigs', {
+    query: { tag: 'SIG' },
+  }).then(
     (value) => ({ status: 'fulfilled', value }),
     (reason) => ({ status: 'rejected', reason }),
   );

--- a/src/app/us/fund-apply/create/form.tsx
+++ b/src/app/us/fund-apply/create/form.tsx
@@ -173,10 +173,10 @@ export default function FundApplyForm({
     const run = async () => {
       try {
         const [currSigData, currPigData, prevSigData, prevPigData] = await Promise.all([
-          fetchBackendClientJson<any[]>(`/api/sigs?${_curr}`),
-          fetchBackendClientJson<any[]>(`/api/pigs?${_curr}`),
-          fetchBackendClientJson<any[]>(`/api/sigs?${_prev}`),
-          fetchBackendClientJson<any[]>(`/api/pigs?${_prev}`),
+          fetchBackendClientJson<any[]>(`/api/sigs?${_curr}&tag=SIG`),
+          fetchBackendClientJson<any[]>(`/api/sigs?${_curr}&tag=PIG`),
+          fetchBackendClientJson<any[]>(`/api/sigs?${_prev}&tag=SIG`),
+          fetchBackendClientJson<any[]>(`/api/sigs?${_prev}&tag=PIG`),
         ]);
         if (isMounted) {
           setCurrSigs(refinineSigList(currSigData));

--- a/src/util/fetch/client.ts
+++ b/src/util/fetch/client.ts
@@ -28,10 +28,10 @@ function resolveBackendPath(path: string): string {
   if (commentDelete) return `/api/comment/delete/${commentDelete[1]}${suffix}`;
 
   const pigExecutiveUpdate = pathname.match(/^\/api\/pig\/([^/]+)\/update\/executive$/);
-  if (pigExecutiveUpdate) return `/api/executive/pig/${pigExecutiveUpdate[1]}/update${suffix}`;
+  if (pigExecutiveUpdate) return `/api/executive/sig/${pigExecutiveUpdate[1]}/update${suffix}`;
 
   const pigExecutiveDelete = pathname.match(/^\/api\/pig\/([^/]+)\/delete\/executive$/);
-  if (pigExecutiveDelete) return `/api/executive/pig/${pigExecutiveDelete[1]}/delete${suffix}`;
+  if (pigExecutiveDelete) return `/api/executive/sig/${pigExecutiveDelete[1]}/delete${suffix}`;
 
   const sigExecutiveUpdate = pathname.match(/^\/api\/sig\/([^/]+)\/update\/executive$/);
   if (sigExecutiveUpdate) return `/api/executive/sig/${sigExecutiveUpdate[1]}/update${suffix}`;

--- a/src/util/fetch/server-util.ts
+++ b/src/util/fetch/server-util.ts
@@ -205,20 +205,22 @@ export async function fetchFundApplyCreateData(boardId = 6): Promise<FundApplyCr
         year: currentTerm.year,
         semester: currentTerm.semester,
         status: globalStatus?.status,
+        tag: 'SIG',
       },
     }).catch(() => []),
     fetchBackendServerJson('GET', '/api/sigs', {
-      query: { year: prevTerm.year, semester: prevTerm.semester },
+      query: { year: prevTerm.year, semester: prevTerm.semester, tag: 'SIG' },
     }).catch(() => []),
-    fetchBackendServerJson('GET', '/api/pigs', {
+    fetchBackendServerJson('GET', '/api/sigs', {
       query: {
         year: currentTerm.year,
         semester: currentTerm.semester,
         status: globalStatus?.status,
+        tag: 'PIG',
       },
     }).catch(() => []),
-    fetchBackendServerJson('GET', '/api/pigs', {
-      query: { year: prevTerm.year, semester: prevTerm.semester },
+    fetchBackendServerJson('GET', '/api/sigs', {
+      query: { year: prevTerm.year, semester: prevTerm.semester, tag: 'PIG' },
     }).catch(() => []),
   ]);
 


### PR DESCRIPTION
<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->

### What feature does this PR add?
fixed #632 
<!-- Describe the feature or enhancement you implemented -->

---

### Screenshots
<img width="1436" height="877" alt="image" src="https://github.com/user-attachments/assets/5170137c-563f-4874-a2cf-d115dbd570ab" />
<img width="1402" height="707" alt="image" src="https://github.com/user-attachments/assets/a30fe957-94d0-404a-bf6d-3d8bb5123bbd" />


<!--
If your changes affect the UI, please attach before/after screenshots.
If there is no UI change, write "None".
-->

---

### Are there any caveats or things to watch out for?
지금 sig/pig 생성 시 메이저 태그가 없어서 sig/pig 목록에 뜨지 않아 생성 후 메이저 태그를 붙일 수 없습니다. 백엔드나 프론트엔드에서 생성 시 메이저 태그를 붙여야 될 거 같습니다. 
<!-- If none, write "None" -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Refactor**
  * Standardized backend routing so PIG operations now consistently use SIG-based endpoints across create, update (including executive flows), delete, member join/leave, and owner handover.
  * Updated list and detail pages to use unified endpoints with tag-based filtering for `PIG` and `SIG`.
  * Revised fund-application form loading to populate selectable options via tag-filtered requests for both PIG and SIG.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->