### PR TITLE
⚡ Removed underline from board creat btn

### DIFF
--- a/src/components/board/board.module.css
+++ b/src/components/board/board.module.css
@@ -80,6 +80,7 @@
   font-weight: 500;
   cursor: pointer;
   transition: background-color 0.2s ease;
+  text-decoration: none;
 }
 
 .boardCreateBtn:hover {


### PR DESCRIPTION
fixed #591 

이 문제는 별도 css 설정이 아닌, 크롬에서 자동 적용된 user agent stylesheet 문제입니다.
이 문제가 발생한 원인으로 css 설정 overriding이 제대로 되지 않은 것으로 보이는데, module화하면서 기존에 전역 또는 다른 파일의 영향으로 적용된 사항이 적용되지 않게 된 것입니다.
<img width="866" height="203" alt="image" src="https://github.com/user-attachments/assets/98bc82bb-b8fd-4717-b250-434892c39a7d" />

<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->

### What feature does this PR add?

<!-- Describe the feature or enhancement you implemented -->

---

### Screenshots

<!--
If your changes affect the UI, please attach before/after screenshots.
If there is no UI change, write "None".
-->

---

### Are there any caveats or things to watch out for?

<!-- If none, write "None" -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the create button styling to remove underlines and improve visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->