### PR TITLE
💄 Executives / Developers를 footer로 이동

### DIFF
--- a/src/app/Footer.jsx
+++ b/src/app/Footer.jsx
@@ -4,7 +4,8 @@ import styles from './Footer.module.css';
 import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import Image from 'next/image';
-import { hideFooterRoutes, footerLogoData } from '@/util/constants';
+import Link from 'next/link';
+import { hideFooterRoutes, footerLogoData, footerMenuData } from '@/util/constants';
 import { getKvsClient } from '@/util/fetch/client-util';
 
 export default function Footer() {
@@ -48,6 +49,16 @@ export default function Footer() {
                   ))}
               </p>
             </div>
+            <nav className={styles.footerNav} aria-label="People">
+              <span className={styles.footerNavTitle}>People</span>
+              <ul className={styles.footerNavList}>
+                {footerMenuData.map((item) => (
+                  <li key={item.url}>
+                    <Link href={item.url}>{item.label}</Link>
+                  </li>
+                ))}
+              </ul>
+            </nav>
           </div>
         </div>
         <div className={styles.logoList}>

--- a/src/app/Footer.module.css
+++ b/src/app/Footer.module.css
@@ -72,3 +72,44 @@
   white-space: pre-wrap;
   line-height: 1.6;
 }
+
+.footerNav {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1rem;
+  font-size: 0.875rem;
+}
+
+.footerNavTitle {
+  font-weight: 600;
+}
+
+.footerNavList {
+  display: flex;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.footerNavList li + li::before {
+  margin-right: 0.75rem;
+  color: var(--footer-text-color);
+  content: '·';
+  opacity: 0.45;
+}
+
+.footerNavList a {
+  color: var(--footer-text-color);
+  text-decoration: none;
+  opacity: 0.75;
+  transition: opacity 0.2s ease;
+}
+
+.footerNavList a:hover,
+.footerNavList a:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+  opacity: 1;
+}

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -57,8 +57,6 @@ export const headerMenuData: HeaderMenuSection[] = [
     items: [
       { label: 'SCSC', url: '/about' },
       { label: 'Welcome Guide', url: '/about/welcome' },
-      { label: 'Executives', url: '/about/executives' },
-      { label: 'Developers', url: '/about/developers' },
       { label: 'Rules', url: '/about/rules' },
     ],
   },
@@ -84,6 +82,12 @@ export const headerMenuData: HeaderMenuSection[] = [
       { label: 'Fund Apply', url: '/us/fund-apply/create' },
     ],
   },
+];
+
+/** Low-priority informational pages shown in the footer instead of the main navigation. */
+export const footerMenuData: HeaderMenuItem[] = [
+  { label: 'Executives', url: '/about/executives' },
+  { label: 'Developers', url: '/about/developers' },
 ];
 
 export interface FooterLogoItem {

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -84,7 +84,9 @@ export const headerMenuData: HeaderMenuSection[] = [
   },
 ];
 
-/** Low-priority informational pages shown in the footer instead of the main navigation. */
+/**
+ * 푸터에 표시되는 페이지 정보입니다.
+ */
 export const footerMenuData: HeaderMenuItem[] = [
   { label: 'Executives', url: '/about/executives' },
   { label: 'Developers', url: '/about/developers' },


### PR DESCRIPTION
### What feature does this PR add?

fixed #648

기존 About us 항목 아래에 있던 Executives 탭 그리고 developers 탭을 footer로 옮겼습니다.

### Screenshots

<img width="478" height="181" alt="image" src="https://github.com/user-attachments/assets/3e91eb48-aaf5-4552-804a-6af492314c26" />

<img width="354" height="158" alt="image" src="https://github.com/user-attachments/assets/2e4eab68-df9f-4aa4-8246-e236b3e5dbf6" />

### Are there any caveats or things to watch out for?

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "People" navigation section to the footer with links to key pages. The footer navigation now includes dedicated menu items for improved site navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->