### PR TITLE
♻️⚡Reducing hovering animations&border radius usage in "About us" page(+minor bug fixes)

### DIFF
--- a/src/app/about/about.module.css
+++ b/src/app/about/about.module.css
@@ -413,7 +413,6 @@
   text-align: center;
 }
 
-/* Image already sits inside a rounded card — drop the redundant nested rounding */
 .facilityCard .imageWrapper {
   border-radius: 0;
 }
@@ -499,7 +498,6 @@
   transform: translateY(0);
 }
 
-/* Gentle opacity-only reveal (no "fly-up" motion) */
 .fadeIn {
   opacity: 0;
   transition: opacity 0.6s ease-out;

--- a/src/app/about/about.module.css
+++ b/src/app/about/about.module.css
@@ -507,7 +507,6 @@
   opacity: 1;
 }
 
-/* --- Added from faq.css --- */
 .faqContainer {
   display: flex;
   flex-direction: column;

--- a/src/app/about/about.module.css
+++ b/src/app/about/about.module.css
@@ -155,14 +155,6 @@
   overflow: hidden;
 }
 
-.cardHover:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 6px 16px var(--color-card-shadow);
-  transition:
-    transform 0.2s ease,
-    box-shadow 0.2s ease;
-}
-
 /* Shared Image Styles */
 .imageWrapper {
   position: relative;
@@ -421,6 +413,11 @@
   text-align: center;
 }
 
+/* Image already sits inside a rounded card — drop the redundant nested rounding */
+.facilityCard .imageWrapper {
+  border-radius: 0;
+}
+
 .facilityCard h3 {
   margin: 0.25rem 0 0.25rem 0;
   font-weight: 700;
@@ -500,6 +497,16 @@
 .fadeOnScrollVisible {
   opacity: 1;
   transform: translateY(0);
+}
+
+/* Gentle opacity-only reveal (no "fly-up" motion) */
+.fadeIn {
+  opacity: 0;
+  transition: opacity 0.6s ease-out;
+}
+
+.fadeInVisible {
+  opacity: 1;
 }
 
 /* --- Added from faq.css --- */

--- a/src/app/about/page.jsx
+++ b/src/app/about/page.jsx
@@ -6,11 +6,13 @@ import FaqList from '@/components/about/FaqList';
 import Arrow from '@/components/about/Arrow';
 import styles from './about.module.css';
 import Sidebar from '@/components/about/Sidebar.jsx';
-import { getKVValue } from '@/util/fetchAPIData';
+import { getKVValues } from '@/util/fetchAPIData';
 
 export default async function AboutPage() {
   const DEFAULT_DISCORD_INVITE_LINK = 'https://discord.gg/SmXFDxA7XE';
-  const rawDiscordInviteLink = await getKVValue('TEXT_DISCORD_INVITE_LINK');
+  const kv = await getKVValues(['TEXT_DISCORD_INVITE_LINK']);
+  const inviteResult = kv['TEXT_DISCORD_INVITE_LINK'];
+  const rawDiscordInviteLink = inviteResult?.status === 'fulfilled' ? inviteResult.value : '';
   const discordInviteLink = /^https?:\/\/\S+$/i.test(rawDiscordInviteLink)
     ? rawDiscordInviteLink
     : DEFAULT_DISCORD_INVITE_LINK;
@@ -105,7 +107,7 @@ export default async function AboutPage() {
             </section>
           </ScrollEffectWrapper>
 
-          <ScrollEffectWrapper>
+          <ScrollEffectWrapper variant="fade">
             <section id="activities" className={`${styles.section} ${styles.anchorOffset}`}>
               <div className={styles.inner}>
                 <h2>SCSC는 이러한 활동을 합니다</h2>
@@ -144,24 +146,23 @@ export default async function AboutPage() {
                       image: '/about/activities/mt.jpg',
                     },
                   ].map(({ title, description, image }) => (
-                    <ScrollEffectWrapper key={title}>
-                      <div
-                        className={`${styles.card} ${styles.cardHover} ${styles.facilityCard}`}
-                      >
-                        <div className={styles.imageWrapper} style={{ height: '200px' }}>
-                          <Image src={image} alt={title} fill className={styles.image} />
-                        </div>
-                        <h3>{title}</h3>
-                        <p>{description}</p>
+                    <div
+                      key={title}
+                      className={`${styles.card} ${styles.cardHover} ${styles.facilityCard}`}
+                    >
+                      <div className={styles.imageWrapper} style={{ height: '200px' }}>
+                        <Image src={image} alt={title} fill className={styles.image} />
                       </div>
-                    </ScrollEffectWrapper>
+                      <h3>{title}</h3>
+                      <p>{description}</p>
+                    </div>
                   ))}
                 </div>
               </div>
             </section>
           </ScrollEffectWrapper>
 
-          <ScrollEffectWrapper>
+          <ScrollEffectWrapper variant="fade">
             <section id="faq" className={`${styles.section} ${styles.anchorOffset}`}>
               <div className={styles.inner}>
                 <FaqList />
@@ -169,7 +170,7 @@ export default async function AboutPage() {
             </section>
           </ScrollEffectWrapper>
 
-          <ScrollEffectWrapper>
+          <ScrollEffectWrapper variant="fade">
             <section id="clubroom" className={`${styles.section} ${styles.anchorOffset}`}>
               <div className={styles.inner}>
                 <div className={styles.clubroomContainer}>
@@ -207,17 +208,16 @@ export default async function AboutPage() {
                         image: '/about/club-room/games.jpg',
                       },
                     ].map(({ title, description, image }) => (
-                      <ScrollEffectWrapper key={title}>
-                        <div
-                          className={`${styles.card} ${styles.cardHover} ${styles.facilityCard}`}
-                        >
-                          <div className={styles.imageWrapper} style={{ height: '200px' }}>
-                            <Image src={image} alt={title} fill className={styles.image} />
-                          </div>
-                          <h3>{title}</h3>
-                          <p>{description}</p>
+                      <div
+                        key={title}
+                        className={`${styles.card} ${styles.cardHover} ${styles.facilityCard}`}
+                      >
+                        <div className={styles.imageWrapper} style={{ height: '200px' }}>
+                          <Image src={image} alt={title} fill className={styles.image} />
                         </div>
-                      </ScrollEffectWrapper>
+                        <h3>{title}</h3>
+                        <p>{description}</p>
+                      </div>
                     ))}
                   </div>
                 </div>
@@ -225,7 +225,7 @@ export default async function AboutPage() {
             </section>
           </ScrollEffectWrapper>
 
-          <ScrollEffectWrapper>
+          <ScrollEffectWrapper variant="fade">
             <section id="more" className={`${styles.section} ${styles.anchorOffset}`}>
               <div className={styles.inner}>
                 <div className={styles.card}>

--- a/src/components/about/ScrollEffectWrapper.jsx
+++ b/src/components/about/ScrollEffectWrapper.jsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import styles from '@/app/about/about.module.css';
 
-export default function ScrollEffectWrapper({ children }) {
+export default function ScrollEffectWrapper({ children, variant }) {
   const [isVisible, setIsVisible] = useState(false);
   const domRef = useRef();
 
@@ -28,11 +28,13 @@ export default function ScrollEffectWrapper({ children }) {
     };
   }, []);
 
+  // `variant="fade"` does a gentle opacity-only fade (no upward "fly-up" motion).
+  // Default keeps the original translateY fade used elsewhere on the about pages.
+  const baseClass = variant === 'fade' ? styles.fadeIn : styles.fadeOnScroll;
+  const visibleClass = variant === 'fade' ? styles.fadeInVisible : styles.fadeOnScrollVisible;
+
   return (
-    <div
-      className={`${styles.fadeOnScroll} ${isVisible ? styles.fadeOnScrollVisible : ''}`}
-      ref={domRef}
-    >
+    <div className={`${baseClass} ${isVisible ? visibleClass : ''}`} ref={domRef}>
       {children}
     </div>
   );

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -27,6 +27,13 @@ export async function middleware(req) {
     return NextResponse.next();
   }
 
+  // Static asset files (images, etc.) must bypass auth: Next's image optimizer
+  // fetches these server-side without the user's session cookie, so protecting
+  // them would redirect the fetch to login and break image optimization.
+  if (/\.(jpe?g|png|gif|svg|webp|avif|ico)$/i.test(pathname)) {
+    return NextResponse.next();
+  }
+
   const userAgent = req.headers.get('user-agent')?.toLowerCase() || '';
 
   const kakaotalk = ['kakao', 'kakaotalk'];


### PR DESCRIPTION
### What feature does this PR add?
fixed #649 

 ### 애니메이션 정리
- **카드 등장 애니메이션 제거**: '활동' / '동아리 시설' 섹션의 카드들이 스크롤 시 하나씩 날아오르던 애니메이션(`ScrollEffectWrapper`) 제거. 이제 카드들은 섹션과 함께 자연스럽게 나타나게 됨.
- **카드 호버 효과 제거**: 카드에 마우스를 올리면 위로 떠오르던 효과(`.cardHover`) 제거 (미사용이 된 CSS 규칙도 함께 삭제)
- **섹션 등장 방식 변경**: '활동', 'FAQ', '동아리 시설', '더 알아보기' 섹션이 30px 위로 날아오르며 나타나던 효과를, 부드러운 페이드 인(opacity)으로 변경.

### border-radius 정리
- **카드 이미지의 중첩된 둥근 모서리 제거**: 이미 둥근 카드 안의 이미지에도 별도로 border-radius가 적용되어 '둥근 모서리 안의 둥근 모서리' 형태였는데, 카드 이미지의 모서리를 직각으로 변경해 깔끔하게 정리.

---

### Screenshots

<img width="896" height="689" alt="Screenshot 2026-06-22 at 9 42 50 PM" src="https://github.com/user-attachments/assets/64e6e37f-bf42-4ab6-af2c-c2eaf10409fe" />
-이미지 테두리: 직각
-카드 위에 커서를 가져다대도 호버링 효과 X

---

### Are there any caveats or things to watch out for?
이 PR에는 #649 작업 중 발견한 **기존 버그 2건**도 함께 포함해서 PR 올립니다. 둘 다 About 페이지 동작/확인을 막고 있어서 한 번에 수정했습니다.

1. **About 페이지 크래시 수정 (`page.jsx`)**: `getKVValue`(단수)를 import해 호출하고 있었으나, `server-util`에는 `getKVValues`(복수, 배열 인자)만 존재해 `is not a function` 런타임 에러로 페이지 전체가 렌더링되지 않았습니다. `getKVValues`를 사용하도록 수정했습니다.

2. **About 이미지 최적화 실패 수정 (`middleware.js`)**: 미들웨어 matcher의 `/about/:path*`가 `public/about/...`의 정적 이미지 경로까지 가로채고 있었습니다. Next 이미지 최적화기가 서버 사이드에서 이미지를 가져올 때는 세션 쿠키가 없어 로그인으로 리다이렉트되었고, 결과적으로 `"isn't a valid image ... received null"` 에러로 이미지가 표시되지 않았습니다. 이미지 확장자 경로는 인증을 건너뛰도록 예외 처리를 추가했습니다.
**참고**: 이 문제는 About뿐 아니라 matcher에 걸리는 경로 하위에 정적 에셋을 둘 경우 동일하게 발생할 수 있어, 팀 차원에서 별도 이슈로 다룰 가치가 있다는 생각입니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fade-in animation option for scroll-revealed sections via an updated page wrapper.

* **UI / Style**
  * Updated About page card animations to use opacity-only fading (replacing translate-on-scroll motion).
  * Simplified card rendering by applying fade wrappers to sections instead of every individual card.
  * Removed hover lift/shadow from facility cards and adjusted facility image corner rounding.

* **Performance**
  * Improved middleware by bypassing auth/redirect logic for common static asset requests.

* **Bug Fixes**
  * Updated the Discord invite link retrieval to use fetched key/value results with a safe fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->