### PR TITLE
✨ 로그인 시 보여지는 구글 계정 @snu.ac.kr으로 제한하기

### DIFF
--- a/src/util/authOptions.ts
+++ b/src/util/authOptions.ts
@@ -38,6 +38,11 @@ export const authOptions: NextAuthOptions = {
     Google({
       clientId: googleClientId,
       clientSecret: googleClientSecret,
+      ...(process.env.SNU_EMAIL_CHECK === 'TRUE' && {
+        authorization: {
+          params: { hd: 'snu.ac.kr' },
+        },
+      }),
     }),
   ],
   callbacks: {

--- a/src/util/authOptions.ts
+++ b/src/util/authOptions.ts
@@ -38,7 +38,7 @@ export const authOptions: NextAuthOptions = {
     Google({
       clientId: googleClientId,
       clientSecret: googleClientSecret,
-      ...(process.env.SNU_EMAIL_CHECK === 'TRUE' && {
+      ...(process.env.SNU_EMAIL_CHECK?.toUpperCase() === 'TRUE' && {
         authorization: {
           params: { hd: 'snu.ac.kr' },
         },

--- a/src/util/authOptions.ts
+++ b/src/util/authOptions.ts
@@ -51,7 +51,10 @@ export const authOptions: NextAuthOptions = {
         return '/us/login?error=no_information';
       }
 
-      if (process.env.SNU_EMAIL_CHECK === 'TRUE' && !validator.email(user.email)) {
+      if (
+        process.env.SNU_EMAIL_CHECK?.toUpperCase() === 'TRUE' &&
+        !validator.email(user.email)
+      ) {
         return '/us/login?error=invalid_email';
       }
 


### PR DESCRIPTION
### What feature does this PR add?

fixed #651 

Google OAuth 로그인 단계에서 @snu.ac.kr 계정으로 유도하도록 hd(hosted domain) 파라미터를 추가함.
- src/util/authOptions.ts의 Google provider 설정에 authorization.params.hd = 'snu.ac.kr'를 추가(SNU_EMAIL_CHECK 환경변수가 TRUE일 때만 적용되게, 로컬 개발 등 해당 변수가 설정되지 않은 경우 기존과 동일하게 동작)

실제 동작
- 이미 @snu.ac.kr 계정 하나로 로그인 했던 사용자의 경우, Google이 선택할 항목이 하나뿐이므로 계정 선택 화면을 건너뛰고 바로 로그인
- 계정 선택 화면이 뜨는 경우(로그인된 계정이 여러 개이거나, 로그인된 계정이 없거나, 최초 동의 시) @snu.ac.kr 계정만 필터링

---

### Screenshots
<img width="2730" height="1478" alt="Screenshot 2026-06-24 at 3 57 14 PM" src="https://github.com/user-attachments/assets/a865544b-c1b4-43d7-9dbb-8803a8635a48" />
-기존 로그인 창


<img width="2722" height="1483" alt="Screenshot 2026-06-24 at 3 56 40 PM" src="https://github.com/user-attachments/assets/6fbc3574-030e-420c-8e77-cd49058264d5" />
-수정된 로그인 창(여러 개의 snu 계정이 등록되어있을 때)

---

### Are there any caveats or things to watch out for?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Google sign-in restrictions for accounts using a specific email domain when enabled, helping limit access to approved users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->