### PR TITLE
✨ Add user activity log page

### DIFF
--- a/src/app/executive/user/activity-logs/ActivityLogList.jsx
+++ b/src/app/executive/user/activity-logs/ActivityLogList.jsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { fetchBackendClientJson } from '@/util/fetch/client';
+
+const LIMIT = 50;
+
+const ACTIVITY_LABELS = {
+  SIGNED_UP: '가입했음',
+  REGISTERED: '등록했음',
+  SIG_JOINED: '시그 가입했음',
+  SIG_LEFT: '시그 탈퇴했음',
+  SIG_LEADER_APPOINTED: '시그장이 됨',
+};
+
+function formatDate(value) {
+  if (!value) return '-';
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  return date.toLocaleString('ko-KR');
+}
+
+function getActivityLabel(activityType) {
+  return ACTIVITY_LABELS[activityType] ?? activityType;
+}
+
+function getShortId(id) {
+  if (!id) return '-';
+  return id.length > 12 ? `${id.slice(0, 12)}...` : id;
+}
+
+function getUserLabel(id, userNameById) {
+  if (!id) return '-';
+
+  const name = userNameById.get(id);
+  if (!name) return getShortId(id);
+
+  return `${name} (${getShortId(id)})`;
+}
+
+export default function ActivityLogList({ users = [] }) {
+  const [logs, setLogs] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const [error, setError] = useState('');
+
+  const observerTargetRef = useRef(null);
+  const nextIdRef = useRef(null);
+  const isLoadingRef = useRef(false);
+  const hasMoreRef = useRef(true);
+
+  const userNameById = useMemo(() => {
+    return new Map(users.map((user) => [user.id, user.name]));
+  }, [users]);
+
+  const loadLogs = useCallback(async () => {
+    if (isLoadingRef.current || !hasMoreRef.current) return;
+
+    isLoadingRef.current = true;
+    setIsLoading(true);
+    setError('');
+
+    const params = new URLSearchParams();
+    params.set('limit', String(LIMIT));
+
+    if (nextIdRef.current !== null) {
+      params.set('next_id', String(nextIdRef.current));
+    }
+
+    try {
+      const query = Object.fromEntries(params.entries());
+
+      const data = await fetchBackendClientJson('GET', '/api/executive/users/activity-logs', {
+        query,
+      });
+
+      const nextLogs = Array.isArray(data) ? data : [];
+
+      setLogs((prev) => {
+        const existingIds = new Set(prev.map((log) => log.id));
+        const uniqueLogs = nextLogs.filter((log) => !existingIds.has(log.id));
+        return [...prev, ...uniqueLogs];
+      });
+
+      if (nextLogs.length < LIMIT) {
+        hasMoreRef.current = false;
+        setHasMore(false);
+      }
+
+      if (nextLogs.length > 0) {
+        nextIdRef.current = nextLogs[nextLogs.length - 1].id;
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '활동 기록을 불러오지 못했습니다.');
+      hasMoreRef.current = false;
+      setHasMore(false);
+    } finally {
+      isLoadingRef.current = false;
+      setIsLoading(false);
+    }
+  }, []);
+
+  const handleRetry = useCallback(() => {
+    setError('');
+    hasMoreRef.current = true;
+    setHasMore(true);
+    loadLogs();
+  }, [loadLogs]);
+
+  useEffect(() => {
+    loadLogs();
+  }, [loadLogs]);
+
+  useEffect(() => {
+    const target = observerTargetRef.current;
+    if (!target) return undefined;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          loadLogs();
+        }
+      },
+      { rootMargin: '200px' },
+    );
+
+    observer.observe(target);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [loadLogs]);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      <div style={{ overflowX: 'auto' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: '900px' }}>
+          <thead>
+            <tr>
+              <th style={headerStyle}>ID</th>
+              <th style={{ ...headerStyle, minWidth: '8rem' }}>활동</th>
+              <th style={headerStyle}>유저</th>
+              <th style={headerStyle}>처리자</th>
+              <th style={headerStyle}>상세</th>
+              <th style={headerStyle}>생성 시각</th>
+            </tr>
+          </thead>
+          <tbody>
+            {logs.map((log) => (
+              <tr key={log.id}>
+                <td style={cellStyle}>{log.id}</td>
+                <td style={{ ...cellStyle, minWidth: '8rem', whiteSpace: 'nowrap' }}>
+                  {getActivityLabel(log.activity_type)}
+                </td>
+                <td style={cellStyle}>{getUserLabel(log.user_id, userNameById)}</td>
+                <td style={cellStyle}>{getUserLabel(log.created_by, userNameById)}</td>
+                <td style={cellStyle}>{log.detail || '-'}</td>
+                <td style={cellStyle}>{formatDate(log.created_at)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {logs.length === 0 && !isLoading && !error && (
+        <p style={{ color: '#767676' }}>아직 유저 활동 기록이 없습니다.</p>
+      )}
+
+      {error && (
+        <div>
+          <p style={{ color: '#d33' }}>{error}</p>
+          <button type="button" onClick={handleRetry}>
+            다시 시도
+          </button>
+        </div>
+      )}
+
+      <div ref={observerTargetRef} style={{ minHeight: '1px' }} />
+
+      {isLoading && <p style={{ color: '#767676' }}>불러오는 중...</p>}
+      {!hasMore && logs.length > 0 && (
+        <p style={{ color: '#767676' }}>마지막 활동 기록입니다.</p>
+      )}
+    </div>
+  );
+}
+
+const headerStyle = {
+  padding: '0.75rem',
+  borderBottom: '1px solid #ddd',
+  textAlign: 'left',
+  whiteSpace: 'nowrap',
+};
+
+const cellStyle = {
+  padding: '0.75rem',
+  borderBottom: '1px solid #eee',
+  verticalAlign: 'top',
+  wordBreak: 'break-all',
+};

--- a/src/app/executive/user/activity-logs/page.jsx
+++ b/src/app/executive/user/activity-logs/page.jsx
@@ -1,0 +1,31 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+import Link from 'next/link';
+import WithAuthorization from '@/components/WithAuthorization';
+import * as AdminLayout from '@/components/AdminLayout';
+import ActivityLogList from './ActivityLogList';
+import { fetchUserSummaries } from '@/util/fetch/server-util';
+
+export default async function UserActivityLogsPage() {
+  const users = await fetchUserSummaries().catch(() => []);
+
+  return (
+    <WithAuthorization>
+      <AdminLayout.AdminPanel>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+          <h2 style={{ margin: 0 }}>유저 활동 기록</h2>
+          <Link href="/executive/user">유저 관리로 돌아가기</Link>
+        </div>
+
+        <p style={{ marginBottom: '1rem', color: '#767676' }}>
+          유저 가입, 등록, 시그 가입/탈퇴, 시그장 임명 기록을 조회합니다.
+        </p>
+
+        <AdminLayout.AdminSection>
+          <ActivityLogList users={users} />
+        </AdminLayout.AdminSection>
+      </AdminLayout.AdminPanel>
+    </WithAuthorization>
+  );
+}

--- a/src/app/executive/user/page.jsx
+++ b/src/app/executive/user/page.jsx
@@ -2,6 +2,7 @@
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
+import Link from 'next/link';
 import WithAuthorization from '@/components/WithAuthorization';
 import LeadershipPanel from './LeadershipPanel';
 import { ReadUserTable } from './UserList';
@@ -61,6 +62,23 @@ export default async function ExecutiveUserPage() {
         <AdminLayout.AdminSection>
           <ReadUserTable users={readUsersSorted} majors={majorsSafe} />
         </AdminLayout.AdminSection>
+
+        <div style={{ margin: '1rem 0 2rem' }}>
+          <Link
+            href="/executive/user/activity-logs"
+            style={{
+              display: 'inline-block',
+              padding: '0.65rem 1rem',
+              borderRadius: '0.5rem',
+              backgroundColor: '#4fc3df',
+              color: '#fff',
+              fontWeight: 700,
+              textDecoration: 'none',
+            }}
+          >
+            유저 활동 기록 보기
+          </Link>
+        </div>
 
         <LeadershipPageLink />
 


### PR DESCRIPTION
Closes #683

### What feature does this PR add?

관리자 페이지에서 유저 활동 기록을 조회할 수 있는 페이지를 추가했습니다.

- `/executive/user/activity-logs` 페이지 추가
- 관리자 유저 관리 페이지에서 유저 활동 기록 페이지로 이동하는 버튼 추가
- 유저 활동 기록 목록 표시
- 무한 스크롤 페이지네이션
- 활동 타입을 한국어 라벨로 표시
- 프론트 API proxy `/api/executive/users/activity-logs` 추가

---

### Screenshots

<img width="1267" height="283" alt="image" src="https://github.com/user-attachments/assets/a5bad30b-d999-44de-887f-7b45e19b8424" />

<img width="1261" height="472" alt="image" src="https://github.com/user-attachments/assets/307602cc-448e-4a22-acc7-d339817f21ae" />


---

### Are there any caveats or things to watch out for?

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new User Activity Logs page for executive users.
  * You can now browse activity history in a table with user names, activity labels, details, and timestamps.
  * The log list loads more items automatically as you scroll, and includes empty-state, loading, and retry handling.
  * Added a navigation link from the user area to quickly open the activity log view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->