### PR TITLE
⚡ SIG/PIG 로그인 리다이렉트 prefetch 문제 수정

### DIFF
--- a/src/app/pig/PigListClient.jsx
+++ b/src/app/pig/PigListClient.jsx
@@ -39,7 +39,7 @@ export default function PigListClient({ pigs }) {
           const pid = String(pig.id);
           const isMine = myOwnedPigIds.has(pid);
           return (
-            <Link key={pig.id} href={`/pig/${pig.id}`} className="pigLink">
+            <Link key={pig.id} href={`/pig/${pig.id}`} prefetch={false} className="pigLink">
               <div className={`pigCard ${isMine ? 'isMine' : ''}`}>
                 <div className="pigTopbar">
                   <span className="pigTitle">{pig.title}</span>

--- a/src/app/sig/SigListClient.jsx
+++ b/src/app/sig/SigListClient.jsx
@@ -162,7 +162,12 @@ export default function SigListClient({ sigs, initialFilterTags = [] }) {
           const tags = Array.isArray(sig?.tags) ? sig.tags : [];
 
           return (
-            <Link key={sig.id} href={`/sig/${sig.id}`} className={styles.sigLink}>
+            <Link
+              key={sig.id}
+              href={`/sig/${sig.id}`}
+              prefetch={false}
+              className={styles.sigLink}
+            >
               <div className={`${styles.sigCard} ${isMine ? styles.isMine : ''}`}>
                 <div className={styles.sigTopbar}>
                   <span className={styles.sigTitle}>{sig.title}</span>


### PR DESCRIPTION
### What feature does this PR add?

- SIG 및 PIG 목록 페이지에서 잘못된 로그인 리다이렉트가 발생하는 문제를 수정했습니다.

- SIG/PIG 상세 페이지를 자동으로 prefetch하면서, 사용자가 실제로 클릭하지 않은 페이지의 경로가 `redirect_after_login` 쿠키에 저장될 수 있었습니다. 이 때문에 목록을 아래로 스크롤한 뒤 위쪽 항목을 클릭해 로그인하면, 실제로 클릭한 항목이 아니라 마지막으로 prefetch된 SIG/PIG 상세 페이지로 이동하는 문제가 있었습니다.

- SIG/PIG 상세 링크에 `prefetch={false}`를 추가하여, 스크롤 중 백그라운드 요청이 발생하지 않도록 수정했습니다. 이제 사용자가 실제로 상세 페이지에 진입한 경우에만 로그인 후 이동 경로가 올바르게 설정됩니다.

Fixed #691

---

### Screenshots

<img width="1034" height="294" alt="image" src="https://github.com/user-attachments/assets/a47e5929-60e1-4176-b495-5679b447e285" />

---

### Are there any caveats or things to watch out for?

SIG/PIG 목록 페이지를 보고 있는 동안에 redirect_after_login이 /us/fund-apply/create 이긴 합니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Disabled automatic prefetching for pig card navigation links to reduce unnecessary background requests.

* **Style**
  * Reformatted SIG card link properties for improved readability without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->