### PR TITLE
⚡ Fix stale protected page redirects

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -58,14 +58,19 @@ export async function middleware(req) {
   if (jwt) return NextResponse.next();
 
   const returnTo = buildReturnPath(req);
+  const shouldPreserveRedirect = returnTo && !isPrefetchRequest(req);
 
   const loginUrl = req.nextUrl.clone();
   loginUrl.pathname = '/us/login';
   loginUrl.search = '';
 
+  if (shouldPreserveRedirect) {
+    loginUrl.searchParams.set('redirect', returnTo);
+  }
+
   const res = NextResponse.redirect(loginUrl);
 
-  if (returnTo && !isPrefetchRequest(req)) {
+  if (shouldPreserveRedirect) {
     res.cookies.set(REDIRECT_COOKIE, returnTo, {
       path: '/',
       maxAge: 300,

--- a/src/util/loginRedirect.ts
+++ b/src/util/loginRedirect.ts
@@ -194,8 +194,18 @@ export function pushLoginWithRedirect(
   options: { redirectTo?: string } = {},
 ): void {
   const { redirectTo } = options;
-  debugLog('push_login_with_redirect', { redirectTo, current: getCurrentPath() });
-  setRedirectAfterLogin(redirectTo);
+  const target = redirectTo ?? getCurrentPath();
+
+  debugLog('push_login_with_redirect', { redirectTo, current: getCurrentPath(), target });
+
+  clearRedirectAfterLogin();
+
+  if (target && isAllowedRedirectPath(target)) {
+    setRedirectAfterLogin(target);
+    router.push(`/us/login?redirect=${encodeURIComponent(target)}`);
+    return;
+  }
+
   router.push('/us/login');
 }
 
@@ -211,7 +221,17 @@ export function replaceLoginWithRedirect(
   options: { redirectTo?: string } = {},
 ): void {
   const { redirectTo } = options;
-  debugLog('replace_login_with_redirect', { redirectTo, current: getCurrentPath() });
-  setRedirectAfterLogin(redirectTo);
+  const target = redirectTo ?? getCurrentPath();
+
+  debugLog('replace_login_with_redirect', { redirectTo, current: getCurrentPath(), target });
+
+  clearRedirectAfterLogin();
+
+  if (target && isAllowedRedirectPath(target)) {
+    setRedirectAfterLogin(target);
+    router.replace(`/us/login?redirect=${encodeURIComponent(target)}`);
+    return;
+  }
+
   router.replace('/us/login');
 }


### PR DESCRIPTION
### What feature does this PR add?

비로그인 상태에서 /about/welcome, /board에 접근하려고 할 때 원래 접근하려던 경로가 로그인 redirect에 제대로 저장되지 않는 버그를 발견하였습니다. 이때 기존에 남아 있던 `redirect_after_login` 쿠키가 `/us/fund-apply/create`이면, 로그인 후 원래 의도한 페이지가 아니라 지원금 신청 페이지로 이동하는 문제도 있었습니다.

이번 PR에서는 다음을 수정했습니다.

- middleware에서 로그인 페이지로 redirect할 때 원래 접근하려던 경로를 `redirect` query parameter로 함께 전달
- 로그인 redirect helper에서 기존 stale redirect 쿠키를 삭제한 뒤 새 redirect target을 저장
- 새 redirect target을 쿠키와 로그인 URL query 양쪽에 반영하도록 수정

---

### Screenshots

None.

---

### Are there any caveats or things to watch out for?

로그인 시 삭제되어 작동에 문제는 없지만 `redirect_after_login=/us/fund-apply/create` 는 계속 남아있는 버그가 있습니다.