### PR TITLE
✨ Add external member application flow

### DIFF
--- a/src/app/api/user/external/register/route.js
+++ b/src/app/api/user/external/register/route.js
@@ -1,0 +1,5 @@
+import { fetchBackendServer } from '@/util/fetch/server';
+
+export async function POST(request) {
+  return fetchBackendServer('POST', '/api/user/external/register', {}, request);
+}

--- a/src/app/api/user/external/register/route.js
+++ b/src/app/api/user/external/register/route.js
@@ -1,5 +1,0 @@
-import { fetchBackendServer } from '@/util/fetch/server';
-
-export async function POST(request) {
-  return fetchBackendServer('POST', '/api/user/external/register', {}, request);
-}

--- a/src/app/executive/user/ExternalMemberManagementPanel.jsx
+++ b/src/app/executive/user/ExternalMemberManagementPanel.jsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { fetchBackendClient } from '@/util/fetch/client';
+import { utc2kst } from '@/util/constants';
+import * as AdminLayout from '@/components/AdminLayout';
+
+export default function ExternalMemberManagementPanel() {
+  const [applicants, setApplicants] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState({});
+
+  useEffect(() => {
+    const fetchApplicants = async () => {
+      try {
+        const response = await fetchBackendClient('/api/executive/user/external/applicants');
+
+        if (!response.ok) {
+          throw new Error(`신청 목록 조회 실패: ${response.status}`);
+        }
+
+        setApplicants(await response.json());
+      } catch (error) {
+        console.error(error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchApplicants();
+  }, []);
+
+  const processApplication = async (application, action) => {
+    const actionLabel = action === 'approve' ? '승인' : '거절';
+
+    if (
+      !window.confirm(
+        `${application.name}님의 외부회원 가입 신청을 ${actionLabel}하시겠습니까?`,
+      )
+    ) {
+      return;
+    }
+
+    setSaving((previous) => ({
+      ...previous,
+      [application.id]: true,
+    }));
+
+    try {
+      const response = await fetchBackendClient(
+        `/api/executive/user/external/${application.id}/${action}`,
+        {
+          method: 'POST',
+        },
+      );
+
+      if (!response.ok) {
+        let detail = null;
+
+        try {
+          detail = (await response.json())?.detail;
+        } catch {
+          detail = null;
+        }
+
+        alert(`${application.name}님 ${actionLabel} 실패: ${detail || response.status}`);
+        return;
+      }
+
+      setApplicants((previous) => previous.filter((item) => item.id !== application.id));
+
+      alert(`${application.name}님 외부회원 가입 신청 ${actionLabel} 완료`);
+    } finally {
+      setSaving((previous) => ({
+        ...previous,
+        [application.id]: false,
+      }));
+    }
+  };
+
+  return (
+    <div>
+      <h2>외부회원 가입 신청자 목록</h2>
+
+      {loading ? (
+        <p>신청 목록을 불러오는 중입니다.</p>
+      ) : (
+        <AdminLayout.AdminTableWrap>
+          <AdminLayout.AdminTable>
+            <thead>
+              <tr>
+                <th>이름</th>
+                <th>이메일</th>
+                <th>전화번호</th>
+                <th>학번</th>
+                <th>신청 사유</th>
+                <th>신청 시각</th>
+                <th>처리</th>
+              </tr>
+            </thead>
+
+            <tbody>
+              {applicants.length === 0 ? (
+                <tr>
+                  <td colSpan={7}>대기 중인 외부회원 가입 신청이 없습니다.</td>
+                </tr>
+              ) : (
+                applicants.map((application) => {
+                  const isSaving = Boolean(saving[application.id]);
+
+                  return (
+                    <tr key={application.id}>
+                      <td>{application.name}</td>
+                      <td>{application.email}</td>
+                      <td>{application.phone}</td>
+                      <td>{application.student_id || '-'}</td>
+                      <td>{application.reason || '-'}</td>
+                      <td>{utc2kst(application.created_at)}</td>
+                      <td>
+                        <div
+                          style={{
+                            display: 'flex',
+                            gap: '0.5rem',
+                            justifyContent: 'center',
+                          }}
+                        >
+                          <AdminLayout.AdminButton
+                            type="button"
+                            disabled={isSaving}
+                            onClick={() => processApplication(application, 'approve')}
+                          >
+                            승인
+                          </AdminLayout.AdminButton>
+
+                          <AdminLayout.AdminButton
+                            type="button"
+                            disabled={isSaving}
+                            onClick={() => processApplication(application, 'reject')}
+                          >
+                            거절
+                          </AdminLayout.AdminButton>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </AdminLayout.AdminTable>
+        </AdminLayout.AdminTableWrap>
+      )}
+    </div>
+  );
+}

--- a/src/app/executive/user/ExternalMemberManagementPanel.jsx
+++ b/src/app/executive/user/ExternalMemberManagementPanel.jsx
@@ -8,6 +8,7 @@ import * as AdminLayout from '@/components/AdminLayout';
 export default function ExternalMemberManagementPanel() {
   const [applicants, setApplicants] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
   const [saving, setSaving] = useState({});
 
   useEffect(() => {
@@ -19,9 +20,16 @@ export default function ExternalMemberManagementPanel() {
           throw new Error(`신청 목록 조회 실패: ${response.status}`);
         }
 
-        setApplicants(await response.json());
+        const data = await response.json();
+
+        if (!Array.isArray(data)) {
+          throw new Error('신청 목록 응답 형식이 올바르지 않습니다.');
+        }
+
+        setApplicants(data);
       } catch (error) {
         console.error(error);
+        setError(error instanceof Error ? error.message : '신청 목록을 불러오지 못했습니다.');
       } finally {
         setLoading(false);
       }
@@ -70,6 +78,9 @@ export default function ExternalMemberManagementPanel() {
       setApplicants((previous) => previous.filter((item) => item.id !== application.id));
 
       alert(`${application.name}님 외부회원 가입 신청 ${actionLabel} 완료`);
+    } catch (error) {
+      console.error(error);
+      alert(`${application.name}님 ${actionLabel} 처리 중 네트워크 오류가 발생했습니다.`);
     } finally {
       setSaving((previous) => ({
         ...previous,
@@ -84,6 +95,8 @@ export default function ExternalMemberManagementPanel() {
 
       {loading ? (
         <p>신청 목록을 불러오는 중입니다.</p>
+      ) : error ? (
+        <p role="alert">{error}</p>
       ) : (
         <AdminLayout.AdminTableWrap>
           <AdminLayout.AdminTable>

--- a/src/app/executive/user/UserList.jsx
+++ b/src/app/executive/user/UserList.jsx
@@ -18,6 +18,7 @@ export function ReadUserTable({ users: usersDefault = [], majors = [] }) {
       100: '휴회원',
       200: '준회원',
       300: '정회원',
+      350: '외부 회원',
       400: '졸업생',
       500: '운영진',
       1000: '회장',

--- a/src/app/executive/user/page.jsx
+++ b/src/app/executive/user/page.jsx
@@ -8,6 +8,7 @@ import LeadershipPanel from './LeadershipPanel';
 import { ReadUserTable } from './UserList';
 import EnrollManagementPanel from './EnrollManagementPanel';
 import OldboyManageMentPanel from './OldboyManagementPanel';
+import ExternalMemberManagementPanel from './ExternalMemberManagementPanel';
 import LeadershipPageLink from './LeadershipPageLink';
 import { getKVValues, fetchUserSummaries } from '@/util/fetch/server-util';
 import { fetchBackendServerJson } from '@/util/fetch/server';
@@ -85,6 +86,10 @@ export default async function ExecutiveUserPage() {
         <AdminLayout.AdminSection>
           <EnrollManagementPanel />
         </AdminLayout.AdminSection>
+        <AdminLayout.AdminSection>
+          <ExternalMemberManagementPanel />
+        </AdminLayout.AdminSection>
+
         <AdminLayout.AdminSection>
           <OldboyManageMentPanel users={readUsers} />
         </AdminLayout.AdminSection>

--- a/src/app/us/(auth)/auth.module.css
+++ b/src/app/us/(auth)/auth.module.css
@@ -170,9 +170,13 @@
 }
 
 .login-description {
-  margin-bottom: 3vh;
+  margin-bottom: 0.5rem;
   text-align: center;
   font-weight: bold;
+}
+
+.google-signin-button-wrapper + .login-description {
+  margin-top: 2.5rem;
 }
 
 .google-signin-button-wrapper {
@@ -182,6 +186,10 @@
   text-align: center;
   z-index: 4;
   position: relative;
+}
+
+.google-signin-button-wrapper .GoogleLoginBtn {
+  margin-top: 0;
 }
 
 .GoogleLoginBtn {

--- a/src/app/us/(auth)/external-register/ExternalRegisterClient.jsx
+++ b/src/app/us/(auth)/external-register/ExternalRegisterClient.jsx
@@ -20,6 +20,7 @@ export default function ExternalRegisterClient({ email, name, submitApplication 
   });
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const [privacyAgreed, setPrivacyAgreed] = useState(false);
 
   const handleSubmit = async (event) => {
     event.preventDefault();
@@ -138,15 +139,27 @@ export default function ExternalRegisterClient({ email, name, submitApplication 
               }}
             />
 
-            <p className={`${styles.PolicyLink} ${styles.agree}`}>
-              신청 시 개인정보 처리방침에 동의합니다.
-            </p>
+            <label className={`${styles.PolicyLink} ${styles.agree}`}>
+              <input
+                type="checkbox"
+                checked={privacyAgreed}
+                onChange={(event) => setPrivacyAgreed(event.target.checked)}
+              />{' '}
+              <a
+                href="https://github.com/scsc-init/homepage_init/blob/master/%EA%B0%9C%EC%9D%B8%EC%A0%95%EB%B3%B4%EC%B2%98%EB%A6%AC%EB%B0%A9%EC%B9%A8.md"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                개인정보 처리방침
+              </a>
+              에 동의합니다.
+            </label>
             <p>가입 신청 후 임원진 승인 전까지 로그인할 수 없습니다.</p>
 
             <button
               type="submit"
               className={`${styles.SignupBtn} ${submitting ? styles['is-disabled'] : ''}`}
-              disabled={submitting || !email || !name || !form.phone}
+              disabled={submitting || !email || !name || !form.phone || !privacyAgreed}
             >
               {submitting ? '신청 중...' : '가입 신청하기'}
             </button>

--- a/src/app/us/(auth)/external-register/ExternalRegisterClient.jsx
+++ b/src/app/us/(auth)/external-register/ExternalRegisterClient.jsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import InquiryButton from '@/components/InquiryButton';
+import * as validator from '@/util/validator';
+import styles from '../auth.module.css';
+import '@/styles/theme.css';
+
+function cleanName(raw) {
+  if (!raw) return '';
+
+  return raw
+    .normalize('NFC')
+    .replace(/^[\s\-\u00AD\u2010-\u2015]+/u, '')
+    .split('/')[0]
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function validateWithCallback(validate, value) {
+  return new Promise((resolve) => {
+    validate(value, resolve);
+  });
+}
+
+export default function ExternalRegisterClient() {
+  const { data: session } = useSession();
+  const [form, setForm] = useState({
+    email: '',
+    name: '',
+    phone: '',
+    student_id: '',
+    reason: '',
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  useEffect(() => {
+    setForm((previous) => ({
+      ...previous,
+      email: session?.user?.email?.toLowerCase() ?? '',
+      name: cleanName(session?.user?.name ?? ''),
+    }));
+  }, [session]);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+
+    if (submitting) return;
+
+    const phone = form.phone.replace(/\D/g, '');
+    const studentId = form.student_id.replace(/\D/g, '');
+
+    const validPhone = await validateWithCallback(validator.phoneNumber, phone);
+    if (!validPhone) {
+      alert('전화번호 형식이 올바르지 않습니다.');
+      return;
+    }
+
+    if (studentId) {
+      const validStudentId = await validateWithCallback(validator.studentID, studentId);
+
+      if (!validStudentId) {
+        alert('학번 형식이 올바르지 않습니다.');
+        return;
+      }
+    }
+
+    setSubmitting(true);
+
+    try {
+      const response = await fetch('/api/user/external/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          email: form.email,
+          name: form.name,
+          phone,
+          student_id: studentId || null,
+          reason: form.reason.trim() || null,
+          hashToken: session?.hashToken,
+        }),
+      });
+
+      if (response.status === 201) {
+        setSubmitted(true);
+        return;
+      }
+
+      let data = null;
+      try {
+        data = await response.json();
+      } catch {
+        data = null;
+      }
+
+      if (response.status === 409) {
+        alert('이미 외부회원 가입 신청이 접수된 이메일입니다.');
+        return;
+      }
+
+      alert(data?.detail || '가입 신청 중 오류가 발생했습니다.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div id={styles.GoogleSignupContainer}>
+      <div className={styles.GoogleSignupCard}>
+        {submitted ? (
+          <div style={{ marginTop: '10vh', textAlign: 'center' }}>
+            <h2>가입 신청이 접수되었습니다.</h2>
+            <p>임원진의 승인 후 외부회원으로 로그인할 수 있습니다.</p>
+            <button type="button" onClick={() => (window.location.href = '/')}>
+              홈으로 이동
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} style={{ marginTop: '4vh' }}>
+            <h2>외부회원 가입 신청</h2>
+
+            <p>이메일</p>
+            <input
+              value={form.email}
+              disabled
+              style={{ width: '100%', boxSizing: 'border-box' }}
+            />
+
+            <p>이름</p>
+            <input
+              value={form.name}
+              disabled
+              style={{ width: '100%', boxSizing: 'border-box' }}
+            />
+
+            <p>전화번호</p>
+            <input
+              value={form.phone}
+              onChange={(event) =>
+                setForm({
+                  ...form,
+                  phone: event.target.value.replace(/\D/g, '').slice(0, 11),
+                })
+              }
+              placeholder="01012345678"
+              inputMode="numeric"
+              required
+              style={{ width: '100%', boxSizing: 'border-box' }}
+            />
+
+            <p>학번 (선택)</p>
+            <input
+              value={form.student_id}
+              onChange={(event) =>
+                setForm({
+                  ...form,
+                  student_id: event.target.value.replace(/\D/g, '').slice(0, 9),
+                })
+              }
+              placeholder="서울대학교 학번이 있는 경우 입력"
+              inputMode="numeric"
+              style={{ width: '100%', boxSizing: 'border-box' }}
+            />
+
+            <p>가입 신청 사유 (선택)</p>
+            <textarea
+              value={form.reason}
+              onChange={(event) =>
+                setForm({
+                  ...form,
+                  reason: event.target.value.slice(0, 1000),
+                })
+              }
+              placeholder="SCSC 외부회원으로 가입하려는 이유를 입력해주세요."
+              rows={5}
+              style={{ width: '100%', boxSizing: 'border-box', resize: 'vertical' }}
+            />
+
+            <p className={`${styles.PolicyLink} ${styles.agree}`}>
+              신청 시 개인정보 처리방침에 동의합니다.
+            </p>
+
+            <button
+              type="submit"
+              className={`${styles.SignupBtn} ${submitting ? styles['is-disabled'] : ''}`}
+              disabled={submitting || !form.email || !form.name || !form.phone}
+            >
+              {submitting ? '신청 중...' : '가입 신청하기'}
+            </button>
+          </form>
+        )}
+      </div>
+
+      <InquiryButton />
+    </div>
+  );
+}

--- a/src/app/us/(auth)/external-register/ExternalRegisterClient.jsx
+++ b/src/app/us/(auth)/external-register/ExternalRegisterClient.jsx
@@ -65,6 +65,9 @@ export default function ExternalRegisterClient({ email, name, submitApplication 
       }
 
       alert(result.detail || '가입 신청 중 오류가 발생했습니다.');
+    } catch (error) {
+      console.error(error);
+      alert('가입 신청 중 네트워크 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
     } finally {
       setSubmitting(false);
     }

--- a/src/app/us/(auth)/external-register/ExternalRegisterClient.jsx
+++ b/src/app/us/(auth)/external-register/ExternalRegisterClient.jsx
@@ -1,22 +1,10 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { useSession } from 'next-auth/react';
+import { useState } from 'react';
 import InquiryButton from '@/components/InquiryButton';
 import * as validator from '@/util/validator';
 import styles from '../auth.module.css';
 import '@/styles/theme.css';
-
-function cleanName(raw) {
-  if (!raw) return '';
-
-  return raw
-    .normalize('NFC')
-    .replace(/^[\s\-\u00AD\u2010-\u2015]+/u, '')
-    .split('/')[0]
-    .replace(/\s+/g, ' ')
-    .trim();
-}
 
 function validateWithCallback(validate, value) {
   return new Promise((resolve) => {
@@ -24,25 +12,14 @@ function validateWithCallback(validate, value) {
   });
 }
 
-export default function ExternalRegisterClient() {
-  const { data: session } = useSession();
+export default function ExternalRegisterClient({ email, name, submitApplication }) {
   const [form, setForm] = useState({
-    email: '',
-    name: '',
     phone: '',
     student_id: '',
     reason: '',
   });
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
-
-  useEffect(() => {
-    setForm((previous) => ({
-      ...previous,
-      email: session?.user?.email?.toLowerCase() ?? '',
-      name: cleanName(session?.user?.name ?? ''),
-    }));
-  }, [session]);
 
   const handleSubmit = async (event) => {
     event.preventDefault();
@@ -70,38 +47,23 @@ export default function ExternalRegisterClient() {
     setSubmitting(true);
 
     try {
-      const response = await fetch('/api/user/external/register', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          email: form.email,
-          name: form.name,
-          phone,
-          student_id: studentId || null,
-          reason: form.reason.trim() || null,
-          hashToken: session?.hashToken,
-        }),
+      const result = await submitApplication({
+        phone,
+        student_id: studentId || null,
+        reason: form.reason.trim() || null,
       });
 
-      if (response.status === 201) {
+      if (result.status === 201) {
         setSubmitted(true);
         return;
       }
 
-      let data = null;
-      try {
-        data = await response.json();
-      } catch {
-        data = null;
-      }
-
-      if (response.status === 409) {
+      if (result.status === 409) {
         alert('이미 외부회원 가입 신청이 접수된 이메일입니다.');
         return;
       }
 
-      alert(data?.detail || '가입 신청 중 오류가 발생했습니다.');
+      alert(result.detail || '가입 신청 중 오류가 발생했습니다.');
     } finally {
       setSubmitting(false);
     }
@@ -113,7 +75,8 @@ export default function ExternalRegisterClient() {
         {submitted ? (
           <div style={{ marginTop: '10vh', textAlign: 'center' }}>
             <h2>가입 신청이 접수되었습니다.</h2>
-            <p>임원진의 승인 후 외부회원으로 로그인할 수 있습니다.</p>
+            <p>가입 신청 후 임원진에게 별도로 연락해 주세요.</p>
+            <p>임원진의 확인 및 승인 후 외부회원으로 로그인할 수 있습니다.</p>
             <button type="button" onClick={() => (window.location.href = '/')}>
               홈으로 이동
             </button>
@@ -123,18 +86,10 @@ export default function ExternalRegisterClient() {
             <h2>외부회원 가입 신청</h2>
 
             <p>이메일</p>
-            <input
-              value={form.email}
-              disabled
-              style={{ width: '100%', boxSizing: 'border-box' }}
-            />
+            <input value={email} disabled style={{ width: '100%', boxSizing: 'border-box' }} />
 
             <p>이름</p>
-            <input
-              value={form.name}
-              disabled
-              style={{ width: '100%', boxSizing: 'border-box' }}
-            />
+            <input value={name} disabled style={{ width: '100%', boxSizing: 'border-box' }} />
 
             <p>전화번호</p>
             <input
@@ -176,17 +131,22 @@ export default function ExternalRegisterClient() {
               }
               placeholder="SCSC 외부회원으로 가입하려는 이유를 입력해주세요."
               rows={5}
-              style={{ width: '100%', boxSizing: 'border-box', resize: 'vertical' }}
+              style={{
+                width: '100%',
+                boxSizing: 'border-box',
+                resize: 'vertical',
+              }}
             />
 
             <p className={`${styles.PolicyLink} ${styles.agree}`}>
               신청 시 개인정보 처리방침에 동의합니다.
             </p>
+            <p>가입 신청 후 임원진 승인 전까지 로그인할 수 없습니다.</p>
 
             <button
               type="submit"
               className={`${styles.SignupBtn} ${submitting ? styles['is-disabled'] : ''}`}
-              disabled={submitting || !form.email || !form.name || !form.phone}
+              disabled={submitting || !email || !name || !form.phone}
             >
               {submitting ? '신청 중...' : '가입 신청하기'}
             </button>

--- a/src/app/us/(auth)/external-register/page.jsx
+++ b/src/app/us/(auth)/external-register/page.jsx
@@ -19,6 +19,12 @@ function cleanName(raw) {
     .trim();
 }
 
+function validateWithCallback(validate, value) {
+  return new Promise((resolve) => {
+    validate(value, resolve);
+  });
+}
+
 async function submitExternalMemberApplication(form) {
   'use server';
 
@@ -40,16 +46,51 @@ async function submitExternalMemberApplication(form) {
     };
   }
 
-  const response = await fetchBackendServer('POST', '/api/user/external/register', {
-    body: {
-      email,
-      name: cleanName(session.user.name),
-      phone: form.phone,
-      student_id: form.student_id || null,
-      reason: form.reason || null,
-      hashToken: session.hashToken,
-    },
-  });
+  const phone = String(form?.phone ?? '').replace(/\D/g, '');
+  const studentId = String(form?.student_id ?? '').replace(/\D/g, '');
+  const reason = typeof form?.reason === 'string' ? form.reason.trim().slice(0, 1000) : '';
+
+  const validPhone = await validateWithCallback(validator.phoneNumber, phone);
+
+  if (!validPhone) {
+    return {
+      status: 400,
+      detail: '전화번호 형식이 올바르지 않습니다.',
+    };
+  }
+
+  if (studentId) {
+    const validStudentId = await validateWithCallback(validator.studentID, studentId);
+
+    if (!validStudentId) {
+      return {
+        status: 400,
+        detail: '학번 형식이 올바르지 않습니다.',
+      };
+    }
+  }
+
+  let response;
+
+  try {
+    response = await fetchBackendServer('POST', '/api/user/external/register', {
+      body: {
+        email,
+        name: cleanName(session.user.name),
+        phone,
+        student_id: studentId || null,
+        reason: reason || null,
+        hashToken: session.hashToken,
+      },
+    });
+  } catch (error) {
+    console.error(error);
+
+    return {
+      status: 503,
+      detail: '서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.',
+    };
+  }
 
   let data = null;
 

--- a/src/app/us/(auth)/external-register/page.jsx
+++ b/src/app/us/(auth)/external-register/page.jsx
@@ -8,6 +8,63 @@ import * as validator from '@/util/validator';
 export const revalidate = 0;
 export const dynamic = 'force-dynamic';
 
+function cleanName(raw) {
+  if (!raw) return '';
+
+  return raw
+    .normalize('NFC')
+    .replace(/^[\s\-\u00AD\u2010-\u2015]+/u, '')
+    .split('/')[0]
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+async function submitExternalMemberApplication(form) {
+  'use server';
+
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.email || !session?.user?.name || !session?.hashToken) {
+    return {
+      status: 401,
+      detail: '로그인 정보가 만료되었습니다. 다시 로그인해주세요.',
+    };
+  }
+
+  const email = session.user.email.toLowerCase();
+
+  if (validator.email(email)) {
+    return {
+      status: 403,
+      detail: 'SNU 계정은 일반 회원가입을 이용해주세요.',
+    };
+  }
+
+  const response = await fetchBackendServer('POST', '/api/user/external/register', {
+    body: {
+      email,
+      name: cleanName(session.user.name),
+      phone: form.phone,
+      student_id: form.student_id || null,
+      reason: form.reason || null,
+      hashToken: session.hashToken,
+    },
+  });
+
+  let data = null;
+
+  try {
+    data = await response.json();
+  } catch {
+    data = null;
+  }
+
+  return {
+    status: response.status,
+    detail: data?.detail ?? null,
+  };
+}
+
 export default async function ExternalRegisterPage() {
   const session = await getServerSession(authOptions);
 
@@ -15,13 +72,15 @@ export default async function ExternalRegisterPage() {
     redirect('/us/login');
   }
 
-  if (validator.email(session.user.email.toLowerCase())) {
+  const email = session.user.email.toLowerCase();
+
+  if (validator.email(email)) {
     redirect('/us/register');
   }
 
   const res = await fetchBackendServer('POST', '/api/user/login', {
     body: {
-      email: session.user.email,
+      email,
       hashToken: session.hashToken,
     },
   });
@@ -34,5 +93,11 @@ export default async function ExternalRegisterPage() {
     redirect('/us/login');
   }
 
-  return <ExternalRegisterClient />;
+  return (
+    <ExternalRegisterClient
+      email={email}
+      name={cleanName(session.user.name)}
+      submitApplication={submitExternalMemberApplication}
+    />
+  );
 }

--- a/src/app/us/(auth)/external-register/page.jsx
+++ b/src/app/us/(auth)/external-register/page.jsx
@@ -1,6 +1,6 @@
 import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
-import AuthClient from './AuthClient';
+import ExternalRegisterClient from './ExternalRegisterClient';
 import { authOptions } from '@/util/authOptions';
 import { fetchBackendServer } from '@/util/fetch/server';
 import * as validator from '@/util/validator';
@@ -8,36 +8,31 @@ import * as validator from '@/util/validator';
 export const revalidate = 0;
 export const dynamic = 'force-dynamic';
 
-export default async function RegisterPage() {
+export default async function ExternalRegisterPage() {
   const session = await getServerSession(authOptions);
+
   if (!session?.user?.email || !session?.user?.name || !session?.hashToken) {
     redirect('/us/login');
   }
 
-  if (!validator.email(session.user.email.toLowerCase())) {
-    redirect('/us/external-register');
+  if (validator.email(session.user.email.toLowerCase())) {
+    redirect('/us/register');
   }
+
   const res = await fetchBackendServer('POST', '/api/user/login', {
     body: {
       email: session.user.email,
       hashToken: session.hashToken,
     },
   });
+
   if (res.status === 200) {
     redirect('/');
   }
+
   if (res.status !== 404) {
     redirect('/us/login');
   }
 
-  const discordLogin = async () => {
-    const res = await fetchBackendServer('POST', '/api/bot/discord/login', {
-      headers: { 'x-api-secret': process.env.API_SECRET || '' },
-    });
-    if (res.status === 204) console.log('봇 로그인 성공');
-    else console.log(`봇 로그인 실패: ${await res.text()}`);
-  };
-  discordLogin();
-
-  return <AuthClient />;
+  return <ExternalRegisterClient />;
 }

--- a/src/app/us/(auth)/login/AuthClient.jsx
+++ b/src/app/us/(auth)/login/AuthClient.jsx
@@ -64,6 +64,9 @@ export default function AuthClient({ initialRedirect = null }) {
       case 'invalid_email':
         alert('SNU 구글 계정(@snu.ac.kr)으로만 로그인할 수 있습니다.');
         break;
+      case 'snu_external_login':
+        alert('서울대학교 계정은 위의 SNU 로그인 버튼을 이용해주세요.');
+        break;
       case 'no_information':
         alert('구글 계정에 등록된 정보가 올바르지 않습니다.');
         break;
@@ -139,7 +142,9 @@ export default function AuthClient({ initialRedirect = null }) {
               if (authLoading) return;
               setAuthLoading(true);
               log('click_login_button', { provider: 'google' });
-              await signIn('google', { callbackUrl: '/us/login/callback' });
+              await signIn('google', {
+                callbackUrl: '/us/login/callback?mode=snu',
+              });
             }}
             disabled={inAppWarning || authLoading}
             aria-disabled={inAppWarning || authLoading}
@@ -153,6 +158,34 @@ export default function AuthClient({ initialRedirect = null }) {
               </svg>
             </span>
             <span className={styles['GoogleLoginText']}>Google 계정으로 로그인</span>
+          </button>
+        </div>
+
+        <p className={styles['login-description']}>외부회원 로그인/회원가입</p>
+        <div className={styles['google-signin-button-wrapper']}>
+          <button
+            type="button"
+            className={styles['GoogleLoginBtn']}
+            onClick={async () => {
+              if (authLoading) return;
+              setAuthLoading(true);
+              log('click_external_login_button', { provider: 'google' });
+              await signIn('google', {
+                callbackUrl: '/us/login/callback?mode=external',
+              });
+            }}
+            disabled={inAppWarning || authLoading}
+            aria-disabled={inAppWarning || authLoading}
+          >
+            <span className={styles['GoogleIcon']} aria-hidden="true">
+              <svg viewBox="0 0 48 48">
+                <path d="M24 9.5c3.7 0 7 1.3 9.6 3.8l6.4-6.4C36.3 3 30.6 1 24 1 14.7 1 6.7 6.3 2.9 14.1l7.9 6.1C12.4 14.9 17.7 9.5 24 9.5z" />
+                <path d="M46.5 24c0-1.6-.2-3.1-.5-4.5H24v9h12.6c-.5 2.7-2.1 5-4.5 6.5l7.1 5.5C43.9 36.9 46.5 30.9 46.5 24z" />
+                <path d="M10.8 28.2c-.5-1.5-.8-3-.8-4.7s.3-3.2.8-4.7l-7.9-6.1C1.1 15.6 0 19.6 0 23.5 0 27.4 1.1 31.4 2.9 34.3l7.9-6.1z" />
+                <path d="M24 47c6.5 0 12.1-2.1 16.1-5.8l-7.1-5.5c-2 1.3-4.6 2.1-9 2.1-6.3 0-11.6-5.4-13.2-10.2l-7.9 6.1C6.7 41.7 14.7 47 24 47z" />
+              </svg>
+            </span>
+            <span className={styles['GoogleLoginText']}>외부회원으로 로그인/회원가입</span>
           </button>
         </div>
       </div>

--- a/src/app/us/(auth)/login/callback/page.jsx
+++ b/src/app/us/(auth)/login/callback/page.jsx
@@ -1,14 +1,17 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { useSession } from 'next-auth/react';
-import { useRouter } from 'next/navigation';
+import { signOut, useSession } from 'next-auth/react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import LoadingSpinner from '@/components/LoadingSpinner';
+import * as validator from '@/util/validator';
 import { consumeRedirectAfterLogin, replaceLoginWithRedirect } from '@/util/loginRedirect';
 
 export default function OAuthLanding() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { data: session, status } = useSession();
+  const mode = searchParams.get('mode') === 'external' ? 'external' : 'snu';
   const didNavigateRef = useRef(false);
 
   useEffect(() => {
@@ -21,6 +24,25 @@ export default function OAuthLanding() {
       return;
     }
 
+    const email = session?.user?.email?.toLowerCase();
+    const isSnuEmail = validator.email(email);
+
+    if (mode === 'snu' && !isSnuEmail) {
+      didNavigateRef.current = true;
+      void signOut({ redirect: false }).then(() => {
+        router.replace('/us/login?error=invalid_email');
+      });
+      return;
+    }
+
+    if (mode === 'external' && isSnuEmail) {
+      didNavigateRef.current = true;
+      void signOut({ redirect: false }).then(() => {
+        router.replace('/us/login?error=snu_external_login');
+      });
+      return;
+    }
+
     if (session?.registered) {
       const redirectTo = consumeRedirectAfterLogin();
       didNavigateRef.current = true;
@@ -29,8 +51,8 @@ export default function OAuthLanding() {
     }
 
     didNavigateRef.current = true;
-    router.replace('/us/register');
-  }, [status, session, router]);
+    router.replace(mode === 'external' ? '/us/external-register' : '/us/register');
+  }, [status, session, router, mode]);
 
   return <LoadingSpinner />;
 }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -96,6 +96,7 @@ const publicRoutes = [
   '/us/login',
   '/us/login/callback',
   '/us/register',
+  '/us/external-register',
 ];
 
 /**

--- a/src/util/fetch/server.ts
+++ b/src/util/fetch/server.ts
@@ -34,6 +34,7 @@ function needApiSecret(path: string): boolean {
   return (
     path.startsWith('/api/user/login') ||
     path.startsWith('/api/user/create') ||
+    path.startsWith('/api/user/external/register') ||
     (ENABLE_TEST_UTILS && path.startsWith('/api/test'))
   );
 }


### PR DESCRIPTION
fixed #699 

### What feature does this PR add?

외부 사용자가 일반 Google 계정으로 외부회원 가입을 신청할 수 있는 기능을 추가하였습니다.
- 기존 SNU Google 계정 로그인과 외부회원 로그인을 분리했습니다.
- 외부 Google 계정 로그인 시 외부회원 가입 신청 페이지로 이동합니다.
- 임원진 사용자 관리 페이지에서 외부회원 신청을 조회하고 승인 또는 거절할 수 있습니다.
---

### Screenshots

<img width="832" height="775" alt="image" src="https://github.com/user-attachments/assets/7ccd6249-59c5-4165-ba0c-942709b0348a" />

<img width="793" height="1012" alt="image" src="https://github.com/user-attachments/assets/ea8a26fa-9f3b-4146-b396-72d623141bc7" />

<img width="2509" height="237" alt="image" src="https://github.com/user-attachments/assets/96ded3d8-8b35-4c5b-8f9a-eba5fce59b8c" />

<img width="751" height="260" alt="image" src="https://github.com/user-attachments/assets/c8f90ac4-9e75-45ba-8c73-e634123512c8" />


---

### Are there any caveats or things to watch out for?

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an external member registration flow (including phone/student ID validation, privacy consent, and success/duplicate handling) with a dedicated external register page.
  * Added an “external member” login option and improved OAuth landing to route correctly for SNU vs external users.
  * Added an executive panel to approve or reject external membership applicants.

* **Bug Fixes / Improvements**
  * Updated user role display to show “외부 회원” for the new role.
  * Improved login/register routing behavior, alerts, and refined login page spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->