### PR TITLE
✨ 파일 첨부 시 확장자 제한

### DIFF
--- a/src/app/article/edit/[id]/EditClient.jsx
+++ b/src/app/article/edit/[id]/EditClient.jsx
@@ -157,7 +157,11 @@ export default function EditClient({ articleId }) {
             onChange={(v) => setValue('editor', v)}
           />
 
-          <AttachmentSection valueIds={attachmentIds} onChangeIds={setAttachmentIds} />
+          <AttachmentSection
+            valueIds={attachmentIds}
+            onChangeIds={setAttachmentIds}
+            isFileUpload
+          />
           <button type="submit" className={styles.CreateBtn} disabled={submitting}>
             {submitting ? '수정 중...' : '수정 완료'}
           </button>

--- a/src/components/board/AttachmentSection.jsx
+++ b/src/components/board/AttachmentSection.jsx
@@ -9,11 +9,11 @@ export default function AttachmentSection({
   valueIds,
   onChangeIds,
   label = '첨부파일',
-  uploadType = 'docs',
+  isImageUpload,
+  isFileUpload,
 }) {
   const [isUploading, setIsUploading] = useState(false);
   const [metadataMap, setMetadataMap] = useState({});
-  const isImageUpload = uploadType === 'image';
 
   const ids = useMemo(() => {
     if (!Array.isArray(valueIds)) return [];
@@ -81,18 +81,16 @@ export default function AttachmentSection({
       if (pickedFiles.length === 0) return;
       if (isUploading) return;
 
-      const invalidFiles =
-        uploadType === 'image'
-          ? pickedFiles.filter((file) => !file.type.startsWith('image/'))
-          : [];
+      const invalidFiles = isImageUpload
+        ? pickedFiles.filter((file) => !file.type.startsWith('image/'))
+        : [];
       if (invalidFiles.length > 0) {
         alert('이미지 파일만 업로드할 수 있습니다.');
       }
 
-      const files =
-        uploadType === 'image'
-          ? pickedFiles.filter((file) => file.type.startsWith('image/'))
-          : pickedFiles;
+      const files = isImageUpload
+        ? pickedFiles.filter((file) => file.type.startsWith('image/'))
+        : pickedFiles;
       if (files.length === 0) return;
 
       setIsUploading(true);
@@ -116,10 +114,13 @@ export default function AttachmentSection({
 
           let res;
           try {
-            res = await fetchBackendClient(`/api/file/${uploadType}/upload`, {
-              method: 'POST',
-              body: formData,
-            });
+            res = await fetchBackendClient(
+              `/api/file/${isImageUpload ? 'image' : 'docs'}/upload`,
+              {
+                method: 'POST',
+                body: formData,
+              },
+            );
           } catch {
             alert('파일 업로드 중 네트워크 오류가 발생했습니다.');
             continue;
@@ -166,7 +167,7 @@ export default function AttachmentSection({
         registerMetadata(uploadedItems);
       }
     },
-    [ids, isUploading, onChangeIds, registerMetadata, uploadType],
+    [ids, isUploading, onChangeIds, registerMetadata, isImageUpload],
   );
 
   const removeId = useCallback(
@@ -177,6 +178,11 @@ export default function AttachmentSection({
     [ids, onChangeIds],
   );
 
+  if (isImageUpload === isFileUpload) {
+    console.error('AttachmentSection: isImageUpload and isFileUpload must differ');
+    return null;
+  }
+
   return (
     <section className="AttachmentSection">
       <div className="AttachmentHeader">
@@ -185,7 +191,7 @@ export default function AttachmentSection({
           <input
             type="file"
             multiple
-            accept={isImageUpload ? 'image/*' : undefined}
+            accept={isImageUpload ? 'image/*' : '.pdf, .docx, .pptx'}
             onChange={onPickFiles}
             disabled={isUploading}
             className="AttachmentInput"

--- a/src/components/board/AttachmentSection.jsx
+++ b/src/components/board/AttachmentSection.jsx
@@ -83,14 +83,24 @@ export default function AttachmentSection({
 
       const invalidFiles = isImageUpload
         ? pickedFiles.filter((file) => !file.type.startsWith('image/'))
-        : [];
+        : pickedFiles.filter((file) => {
+            const name = String(file.name || '').toLowerCase();
+            return !(name.endsWith('.pdf') || name.endsWith('.docx') || name.endsWith('.pptx'));
+          });
       if (invalidFiles.length > 0) {
-        alert('이미지 파일만 업로드할 수 있습니다.');
+        alert(
+          isImageUpload
+            ? '이미지 파일만 업로드할 수 있습니다.'
+            : '지원하지 않는 파일 형식입니다. PDF, DOCX, PPTX 파일만 업로드할 수 있습니다.',
+        );
       }
 
       const files = isImageUpload
         ? pickedFiles.filter((file) => file.type.startsWith('image/'))
-        : pickedFiles;
+        : pickedFiles.filter((file) => {
+            const name = String(file.name || '').toLowerCase();
+            return name.endsWith('.pdf') || name.endsWith('.docx') || name.endsWith('.pptx');
+          });
       if (files.length === 0) return;
 
       setIsUploading(true);
@@ -178,7 +188,7 @@ export default function AttachmentSection({
     [ids, onChangeIds],
   );
 
-  if (isImageUpload === isFileUpload) {
+  if (Boolean(isImageUpload) === Boolean(isFileUpload)) {
     console.error('AttachmentSection: isImageUpload and isFileUpload must differ');
     return null;
   }

--- a/src/components/board/WriteEditorAlbum.jsx
+++ b/src/components/board/WriteEditorAlbum.jsx
@@ -47,7 +47,7 @@ export default function WriteEditorAlbum({ onSubmit, submitting, onDirtyChange }
           <AttachmentSection
             valueIds={attachmentIds}
             onChangeIds={setAttachmentIds}
-            uploadType="image"
+            isImageUpload
           />
         </div>
 

--- a/src/components/board/WriteEditorFile.jsx
+++ b/src/components/board/WriteEditorFile.jsx
@@ -48,7 +48,7 @@ export default function WriteEditorFile({ onSubmit, submitting, onDirtyChange })
           <AttachmentSection
             valueIds={attachmentIds}
             onChangeIds={setAttachmentIds}
-            uploadType="docs"
+            isFileUpload
           />
         </div>
 

--- a/src/components/board/WriteEditorStandard.jsx
+++ b/src/components/board/WriteEditorStandard.jsx
@@ -44,7 +44,7 @@ export default function WriteEditorStandard({ onSubmit, submitting, onDirtyChang
         <AttachmentSection
           valueIds={attachmentIds}
           onChangeIds={setAttachmentIds}
-          uploadType="docs"
+          isFileUpload
         />
         <button type="submit" className={styles.CreateBtn} disabled={submitting}>
           {submitting ? '작성 중...' : '작성 완료'}


### PR DESCRIPTION
<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->

### What feature does this PR add?

<!-- Describe the feature or enhancement you implemented -->

fixed #731 

- `uploadType` 속성 대신 `isImageUpload`, `isFileUpload` boolean 속성 사용
- isFileUpload 일 때 .pdf, .docx, .pptx 확장자 필터 적용

---

### Screenshots

<!--
If your changes affect the UI, please attach before/after screenshots.
If there is no UI change, write "None".
-->

확장자 필터 정상 작동 확인
<img width="1070" height="636" alt="image" src="https://github.com/user-attachments/assets/a3376e30-3761-4bd2-a74d-e3c2882fc679" />

---

### Are there any caveats or things to watch out for?

<!-- If none, write "None" -->
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved attachment handling for image and document uploads.
  - Document attachments are now limited to PDF, DOCX, and PPTX files.
  - Upload controls now correctly distinguish between image and file attachments.
  - Invalid attachment configurations are prevented from rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->